### PR TITLE
Link python3.8 to python

### DIFF
--- a/utils/imod/Dockerfile
+++ b/utils/imod/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:8
 
 ENV IMOD=imod_4.11.11_RHEL7-64_CUDA10.1.sh
 
-RUN yum install -y wget file python38
+RUN yum install -y wget file python38 && ln -fs /usr/bin/python3.8 /usr/bin/python
 RUN  wget https://bio3d.colorado.edu/imod/AMD64-RHEL5/${IMOD} && \
      sh ${IMOD} -yes && \
      rm -f ${IMOD}


### PR DESCRIPTION
Addressed the following error when running dm2mrc:
env: 'python': No such file or directory