### PR TITLE
Added script to manually run test coverage.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,4 @@ repos:
     rev: 5.0.4
     hooks:
       - id: flake8
-    args: [--max-line-length=120, --ignore=E203]
+        args: [--max-line-length=120, --ignore=E203]

--- a/coverage.svg
+++ b/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">80%</text>
+        <text x="80" y="14">80%</text>
+    </g>
+</svg>

--- a/pytest_coverage.sh
+++ b/pytest_coverage.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# The script runs all tests in the directory, outputs a coverage report and then updates a coverage
+# badge for display on the main page.
+# NOTE: this will overwrite the coverage.svg file which must then be committed to Git.
+pytest --cov-report term-missing --cov=.
+coverage-badge -f -o coverage.svg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pytest
 coverage
 pytest-cov
+coverage-badge
 prefect==1.*
 dask
 distributed


### PR DESCRIPTION
The `pytest_coverage.sh` script runs all tests, prints a coverage report and updates the `coverage.svg` badge for display on the main page. The image must then be committed to git for it to take effect.