### PR TITLE
Adding debug option to prevent removal of workdirs, closes #194

### DIFF
--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -486,8 +486,10 @@ with Flow(
     token = Parameter("token", default=None)()
     file_name = Parameter("file_name", default=None)
 
+    # debugging options:
     # run workflow without an api.
     no_api = Parameter("no_api", default=False)()
+    keep_workdir = Parameter("keep_workdir", default=False)()
 
     # a single input_dir will have n tomograms
     input_dir_fp = utils.get_input_dir(input_dir=input_dir)
@@ -615,6 +617,7 @@ with Flow(
     cp_wd_to_assets = utils.copy_workdirs.map(
         fps, upstream_tasks=[callback_with_tilt_mov]
     )
+    rm_workdirs = utils.cleanup_workdir.map(fps, upstream_tasks=[cp_wd_to_assets])
     # finally filter error states, and convert to JSON and send.
     filtered_callback = utils.filter_results(callback_with_tilt_mov)
 

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -229,6 +229,8 @@ with Flow(
     callback_url = Parameter("callback_url", default=None)()
     token = Parameter("token", default=None)()
     no_api = Parameter("no_api", default=None)()
+    # keep workdir if set true, useful to look at outputs
+    keep_workdir = Parameter("keep_workdir", default=False)()
     input_dir_fp = utils.get_input_dir(input_dir=input_dir)
 
     input_fps = utils.list_files(

--- a/em_workflows/file_path.py
+++ b/em_workflows/file_path.py
@@ -263,16 +263,17 @@ class FilePath:
         )
         existing_workdirs = glob.glob(f"{self.assets_dir.as_posix()}/work_dir_*")
         for _dir in existing_workdirs:
-            log(f"Trying to remove {_dir}")
+            log(f"Trying to remove old workdir {_dir}")
             shutil.rmtree(_dir)
         if dest.exists():
+            log(f"Output assets directory already exists! removing: {dest}")
             shutil.rmtree(dest)
         shutil.copytree(self.working_dir, dest)
-        self.rm_workdir()
         return dest
 
     def rm_workdir(self):
         """Removes the the entire working directory"""
+        log(f"Removing working dir: {self.working_dir}")
         shutil.rmtree(self.working_dir)
 
     @staticmethod

--- a/em_workflows/sem_tomo/flow.py
+++ b/em_workflows/sem_tomo/flow.py
@@ -225,7 +225,9 @@ with Flow(
     callback_url = Parameter("callback_url", default=None)()
     token = Parameter("token", default=None)()
     tilt_angle = Parameter("tilt_angle", default=0)()
+    # debugging options:
     no_api = Parameter("no_api", default=False)()
+    keep_workdir = Parameter("keep_workdir", default=False)()
 
     # dir to read from.
     input_dir_fp = utils.get_input_dir(input_dir=input_dir)

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -160,8 +160,11 @@ def cleanup_workdir(fp: FilePath):
     | task wrapper on the FilePath rm_workdir method.
 
     """
-    log(f"Trying to remove {fp.working_dir}")
-    fp.rm_workdir()
+    if context.parameters["keep_workdir"] is not True:
+        log(f"Trying to remove {fp.working_dir}")
+        fp.rm_workdir()
+    else:
+        log("keep_workdir is set to True, skipping removal.")
 
 
 # @task

--- a/test/test_brt.py
+++ b/test/test_brt.py
@@ -77,5 +77,6 @@ def test_brt(mock_nfs_mount, hpc_env):
         THICKNESS=30,
         input_dir="test/input_files/brt_inputs/Projects/",
         no_api=True,
+        keep_workdir=True,
     )
     assert result.is_successful()

--- a/test/test_dm.py
+++ b/test/test_dm.py
@@ -17,6 +17,17 @@ def test_dm4_conv(mock_nfs_mount):
     assert state.is_successful()
 
 
+def test_dm4_conv_clean_workdir(mock_nfs_mount):
+    from em_workflows.dm_conversion.flow import flow
+
+    state = flow.run(
+        input_dir="/test/input_files/dm_inputs/Projects/Lab/PI",
+        no_api=True,
+        # keep_workdir=True
+    )
+    assert state.is_successful()
+
+
 def test_input_fname(mock_nfs_mount):
     from em_workflows.dm_conversion.flow import flow
 


### PR DESCRIPTION
It can be useful to leave workdirs in place, not automatically delete them upon completion of run.
This adds a new top level Param to do this. 
Also surfaces/refactors out workdir rm in brt flow, no longer implicit.
Also adds test.