### PR TITLE
Adding MRC file for test coverage.

### DIFF
--- a/test/input_files/dm_inputs/Projects/Lab/PI/SARsCoV2_1.mrc
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/SARsCoV2_1.mrc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39ee0640e11c1959f810801f4e0f3572c43c9cab4df7f87ca40d534d3ee945f2
+size 33556224


### PR DESCRIPTION
Single file added - it should be handled by Git LFS. It's "only" 33 MB - small for an MRC.