### PR TITLE
Fixed typo in __str__ method

### DIFF
--- a/em_workflows/file_path.py
+++ b/em_workflows/file_path.py
@@ -57,7 +57,7 @@ class FilePath:
         self.prim_fp_elt = self.gen_prim_fp_elt()
         # log(self.__repr__())
 
-    def __str_(self) -> str:
+    def __str__(self) -> str:
         return f"FilePath: proj_root:{self.proj_root}\n\
                 fp_in:{self.fp_in}\n\
                 prim_fp:{self.prim_fp_elt}\n\


### PR DESCRIPTION
I noticed that FilePath wasn't printing out in testing and fixed this typo. I made it a separate PR in case it caused unexpected issues. All tests passed.