### PR TITLE
Hpc fixes

### DIFF
--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -620,7 +620,7 @@ with Flow(
     cb = utils.send_callback_body(
         token=token, callback_url=callback_url, files_elts=filtered_callback
     )
-    rm_workdirs = utils.cleanup_workdir.map(
+    rm_workdirs = utils.cleanup_workdir(
         fps,
         upstream_tasks=[
             cb,

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -615,13 +615,13 @@ with Flow(
     cp_wd_to_assets = utils.copy_workdirs.map(
         fps, upstream_tasks=[callback_with_tilt_mov]
     )
-    rm_workdirs = utils.cleanup_workdir.map(fps, upstream_tasks=[cp_wd_to_assets])
     # finally filter error states, and convert to JSON and send.
     filtered_callback = utils.filter_results(callback_with_tilt_mov)
 
     cb = utils.send_callback_body(
         token=token, callback_url=callback_url, files_elts=filtered_callback
     )
+    rm_workdirs = utils.cleanup_workdir.map(fps, upstream_tasks=[cb])
 
 # the other tasks might be always run or something,
 # this is far enough along to get an idea of success.

--- a/em_workflows/config.py
+++ b/em_workflows/config.py
@@ -15,14 +15,15 @@ def SLURM_exec():
         name="dask-worker",
         cores=60,
         memory="32G",
-        # processes=1,
+        processes=1,
         death_timeout=121,
         local_directory="/gs1/home/macmenaminpe/tmp/",
         queue="gpu",
         walltime="4:00:00",
         job_extra_directives=["--gres=gpu:1"],
     )
-    cluster.adapt(minimum=1, maximum=6)
+    cluster.scale(1)
+    # cluster.adapt(minimum=1, maximum=6)
     logging = prefect.context.get("logger")
     logging.debug("Dask cluster started")
     logging.debug(f"see dashboard {cluster.dashboard_link}")

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -266,9 +266,7 @@ with Flow(
         prim_fp=callback_with_thumbs, asset=keyimg_assets
     )
     # finally filter error states, and convert to JSON and send.
-    rm_workdirs = utils.cleanup_workdir.map(
-        fp=fps, upstream_tasks=[callback_with_keyimgs]
-    )
+    rm_workdirs = utils.cleanup_workdir(fps, upstream_tasks=[callback_with_keyimgs])
     filtered_callback = utils.filter_results(callback_with_keyimgs)
 
     callback_sent = utils.send_callback_body(

--- a/em_workflows/file_path.py
+++ b/em_workflows/file_path.py
@@ -261,10 +261,6 @@ class FilePath:
         dest = Path(
             f"{self.assets_dir.as_posix()}/{dir_name_as_date}/{self.fp_in.stem}"
         )
-        existing_workdirs = glob.glob(f"{self.assets_dir.as_posix()}/work_dir_*")
-        for _dir in existing_workdirs:
-            log(f"Trying to remove old workdir {_dir}")
-            shutil.rmtree(_dir)
         if dest.exists():
             log(f"Output assets directory already exists! removing: {dest}")
             shutil.rmtree(dest)
@@ -274,7 +270,7 @@ class FilePath:
     def rm_workdir(self):
         """Removes the the entire working directory"""
         log(f"Removing working dir: {self.working_dir}")
-        shutil.rmtree(self.working_dir)
+        shutil.rmtree(self.working_dir, ignore_errors=True)
 
     @staticmethod
     def run(cmd: List[str], log_file: str) -> int:

--- a/em_workflows/file_path.py
+++ b/em_workflows/file_path.py
@@ -1,5 +1,4 @@
 import datetime
-import glob
 import shutil
 import os
 from typing import List, Dict
@@ -142,10 +141,10 @@ class FilePath:
         if fp_to_cp.is_dir():
             if dest.exists():
                 shutil.rmtree(dest)
-            shutil.copytree(fp_to_cp, dest)
+            d = shutil.copytree(fp_to_cp, dest)
         else:
-            shutil.copyfile(fp_to_cp, dest)
-        return dest
+            d = shutil.copyfile(fp_to_cp, dest)
+        return Path(d)
 
     # def add_assets_entry(
     #     self, asset_path: Path, asset_type: str, metadata: Dict[str, str] = None

--- a/em_workflows/sem_tomo/flow.py
+++ b/em_workflows/sem_tomo/flow.py
@@ -289,9 +289,7 @@ with Flow(
     callback_with_corr_movies = utils.add_asset.map(
         prim_fp=callback_with_corr_mrcs, asset=corrected_movie_assets
     )
-    rm_workdirs = utils.cleanup_workdir.map(
-        fp=fps, upstream_tasks=[callback_with_corr_movies]
-    )
+    rm_workdirs = utils.cleanup_workdir(fps, upstream_tasks=[callback_with_corr_movies])
 
     # finally filter error states, and convert to JSON and send.
     filtered_callback = utils.filter_results(callback_with_corr_movies)

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -158,7 +158,7 @@ def cleanup_workdir(fp: FilePath):
     | task wrapper on the FilePath rm_workdir method.
 
     """
-    if context.parameters.get("keep_workdir") is True:
+    if prefect.context.parameters.get("keep_workdir") is True:
         log("keep_workdir is set to True, skipping removal.")
     else:
         log(f"Trying to remove {fp.working_dir}")

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -150,7 +150,7 @@ def add_asset(prim_fp: dict, asset: dict) -> dict:
 
 
 @task(max_retries=3, retry_delay=datetime.timedelta(seconds=10), trigger=always_run)
-def cleanup_workdir(fp: FilePath):
+def cleanup_workdir(fps: List[FilePath]):
     """
     :param fp: a FilePath which has a working_dir to be removed
 
@@ -161,8 +161,9 @@ def cleanup_workdir(fp: FilePath):
     if prefect.context.parameters.get("keep_workdir") is True:
         log("keep_workdir is set to True, skipping removal.")
     else:
-        log(f"Trying to remove {fp.working_dir}")
-        fp.rm_workdir()
+        for fp in fps:
+            log(f"Trying to remove {fp.working_dir}")
+            fp.rm_workdir()
 
 
 # @task

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -158,11 +158,11 @@ def cleanup_workdir(fp: FilePath):
     | task wrapper on the FilePath rm_workdir method.
 
     """
-    if context.parameters["keep_workdir"] is not True:
+    if context.parameters.get("keep_workdir") is True:
+        log("keep_workdir is set to True, skipping removal.")
+    else:
         log(f"Trying to remove {fp.working_dir}")
         fp.rm_workdir()
-    else:
-        log("keep_workdir is set to True, skipping removal.")
 
 
 # @task


### PR DESCRIPTION
Always have to use prefect.context (& not context)
Allow the filesystem self throttle speed of removal, no mapping clean up