### PR TITLE
Correct legacy example for metadata

### DIFF
--- a/docs/source/metadata.yml
+++ b/docs/source/metadata.yml
@@ -31,10 +31,10 @@
     "shader": "Grayscale",
     "dimensions": "XYZ",
     "shaderParameters": {
-      "neuroglancerPrecomputedFloor": "-53",
-      "neuroglancerPrecomputedLimit": "58",
-      "neuroglancerPrecomputedMax": "-571",
-      "neuroglancerPrecomputedMin": "370"
+      "neuroglancerPrecomputedMin": "-53",
+      "neuroglancerPrecomputedMax": "58",
+      "neuroglancerPrecomputedFloor": "-571",
+      "neuroglancerPrecomputedLimit": "370"
     }
   }
 


### PR DESCRIPTION
The value ordering was not consistent with the other examples.