### PR TITLE
Add pytest setup fixture to ensure .env file exists

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,14 @@
-BIOFORMATS2RAW=other/binary/dir/openmicroscopy/bioformats2raw
+BIOFORMATS2RAW_LOC=/opt/bin/bioformats2raw-0.7.0/bin/bioformats2raw
+BRT_LOC=/usr/local/IMOD/bin/batchruntomo
+HEADER_LOC=/usr/local/IMOD/bin/header
+MRC2TIF_LOC=/usr/local/IMOD/bin/mrc2tif
+NEWSTACK_LOC=/usr/local/IMOD/bin/newstack
+DM2MRC_LOC=/usr/local/IMOD/bin/dm2mrc
+BINVOL_LOC=/usr/local/IMOD/bin/binvol
+CLIP_LOC=/usr/local/IMOD/bin/clip
+CONVERT_LOC=/usr/bin/convert
+TIF2MRC_LOC=/usr/local/IMOD/bin/tif2mrc
+XFALIGN_LOC=/usr/local/IMOD/bin/xfalign
+XFTOXG_LOC=/usr/local/IMOD/bin/xftoxg
+USER=test
+HEDWIG_ENV=dev

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -124,6 +124,10 @@ The following programs need to be available locally:
 - bioformats2raw package: https://github.com/glencoesoftware/bioformats2raw
 - imagemagick: https://imagemagick.org/script/download.php
 
+All configurations for binary executables that workflows depend on are considered to exist in environment variables.
+For this you will need a `.env` file in the project root directory. For simplicity, you can copy the `.env.sample`
+contents into the `.env` file.
+
 Similar to the HPC Set up below, you can locally set up `dev` and `qa` virtual envs.
 
 Special note for **Mac M1**: The `tomojs-pytools` library depends on imagecodecs which does

--- a/em_workflows/config.py
+++ b/em_workflows/config.py
@@ -62,7 +62,7 @@ def command_loc(cmd: str) -> str:
 class Config:
     # location in RML HPC
     bioformats2raw = os.environ.get(
-        "BIORFORMATS2RAW_LOC",
+        "BIOFORMATS2RAW_LOC",
         "/gs1/apps/user/spack-0.16.0/spack/opt/spack/linux-centos7-sandybridge/gcc-8.3.1/bioformats2raw-0.7.0-7kt7dff7f7fxmdjdk57u6xjuzmsxqodn/bin/bioformats2raw",
     )
     brt_binary = os.environ.get("BRT_LOC", "/opt/rml/imod/bin/batchruntomo")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
-env =
-    HEDWIG_ENV=dev
-    USER=test
+env_override_existing_values = 1
+env_files =
+    .env
 
 addopts =
     --cov-report term-missing --cov-branch --cov-report xml --cov-report term

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,31 +8,14 @@ import os
 from pathlib import Path
 import pytest
 from prefect.executors import LocalExecutor
-from em_workflows.config import command_loc
 
 
 @pytest.fixture
 def mock_binaries(monkeypatch):
     from em_workflows.config import Config
-    from em_workflows.brt.config import BRTConfig
-    from em_workflows.dm_conversion.config import DMConfig
-    from em_workflows.sem_tomo.config import SEMConfig
 
     monkeypatch.setattr(Config, "tmp_dir", "/tmp")
     monkeypatch.setattr(Config, "SLURM_EXECUTOR", LocalExecutor())
-
-    monkeypatch.setattr(BRTConfig, "binvol", command_loc("binvol"))
-    monkeypatch.setattr(Config, "brt_binary", command_loc("batchruntomo"))
-    monkeypatch.setattr(BRTConfig, "clip_loc", command_loc("clip"))
-    monkeypatch.setattr(DMConfig, "dm2mrc_loc", command_loc("dm2mrc"))
-    monkeypatch.setattr(Config, "header_loc", command_loc("header"))
-    monkeypatch.setattr(Config, "mrc2tif_loc", command_loc("mrc2tif"))
-    monkeypatch.setattr(Config, "newstack_loc", command_loc("newstack"))
-    monkeypatch.setattr(SEMConfig, "tif2mrc_loc", command_loc("tif2mrc"))
-    monkeypatch.setattr(SEMConfig, "xfalign_loc", command_loc("xfalign"))
-    monkeypatch.setattr(SEMConfig, "xftoxg_loc", command_loc("xftoxg"))
-    monkeypatch.setattr(SEMConfig, "convert_loc", command_loc("convert"))
-    # monkeypatch.setattr(Config, "bioformats2raw", command_loc("bioformats2raw"))
 
 
 @pytest.fixture
@@ -70,3 +53,26 @@ def mock_callback_data(monkeypatch, tmp_path):
 
     monkeypatch.setattr(utils_json, "dumps", _mock_dumps)
     return str(filename)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def check_env_setup(request):
+    assert os.path.isfile(
+        ".env"
+    ), "Make sure you have .env file setup with \
+            necessary binary filepaths"
+
+    with open(".env", mode="r") as env_file:
+        content = env_file.read()
+        assert "BIOFORMATS2RAW_LOC" in content
+        assert "BRT_LOC" in content
+        assert "HEADER_LOC" in content
+        assert "MRC2TIF_LOC" in content
+        assert "NEWSTACK_LOC" in content
+        assert "DM2MRC_LOC" in content
+        assert "BINVOL_LOC" in content
+        assert "CLIP_LOC" in content
+        assert "CONVERT_LOC" in content
+        assert "TIF2MRC_LOC" in content
+        assert "XFALIGN_LOC" in content
+        assert "XFTOXG_LOC" in content


### PR DESCRIPTION
… with appropriate variables

Addresses https://github.com/niaid/image_portal_workflows/issues/287

### Changes

* Removes monkeypatching `config` in pytest
* Mandates `.env` files (checked only during pytest)

### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [x] tests
