### PR TITLE
Replace strings by Asset type constants

### DIFF
--- a/docs/source/AssetType.yaml
+++ b/docs/source/AssetType.yaml
@@ -4,7 +4,6 @@ enum:
   - thumbnail
   - averagedVolume
   - keyImage
-  - thumbnail
   - recMovie
   - tiltMovie
   - volume

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -48,6 +48,7 @@ from prefect.engine import signals
 
 from em_workflows.utils import utils
 from em_workflows.utils import neuroglancer as ng
+from em_workflows.constants import AssetType
 
 from .config import BRTConfig
 from .constants import BRT_DEPTH, BRT_HEIGHT, BRT_WIDTH
@@ -210,7 +211,9 @@ def gen_thumbs(file_path: FilePath, z_dim) -> dict:
     log_file = f"{file_path.working_dir}/thumb.log"
     FilePath.run(cmd=cmd, log_file=log_file)
     asset_fp = file_path.copy_to_assets_dir(fp_to_cp=Path(thumb))
-    keyimg_asset = file_path.gen_asset(asset_type="thumbnail", asset_fp=asset_fp)
+    keyimg_asset = file_path.gen_asset(
+        asset_type=AssetType.THUMBNAIL, asset_fp=asset_fp
+    )
     return keyimg_asset
 
 
@@ -227,7 +230,9 @@ def gen_copy_keyimages(file_path: FilePath, z_dim: str) -> dict:
     middle_i = calc_middle_i(z_dim=z_dim)
     middle_i_jpg = f"{file_path.working_dir}/{file_path.base}_ali.{middle_i}.jpg"
     asset_fp = file_path.copy_to_assets_dir(fp_to_cp=Path(middle_i_jpg))
-    keyimg_asset = file_path.gen_asset(asset_type="keyImage", asset_fp=asset_fp)
+    keyimg_asset = file_path.gen_asset(
+        asset_type=AssetType.KEY_IMAGE, asset_fp=asset_fp
+    )
     return keyimg_asset
 
 
@@ -273,7 +278,9 @@ def gen_tilt_movie(file_path: FilePath) -> dict:
     ]
     FilePath.run(cmd=cmd, log_file=log_file)
     asset_fp = file_path.copy_to_assets_dir(fp_to_cp=Path(movie_file))
-    tilt_movie_asset = file_path.gen_asset(asset_type="tiltMovie", asset_fp=asset_fp)
+    tilt_movie_asset = file_path.gen_asset(
+        asset_type=AssetType.TILT_MOVIE, asset_fp=asset_fp
+    )
     return tilt_movie_asset
 
 
@@ -312,7 +319,9 @@ def gen_recon_movie(file_path: FilePath) -> dict:
     log_file = f"{file_path.working_dir}/{file_path.base}_keyMov.log"
     FilePath.run(cmd=cmd, log_file=log_file)
     asset_fp = file_path.copy_to_assets_dir(fp_to_cp=Path(key_mov))
-    recon_movie_asset = file_path.gen_asset(asset_type="recMovie", asset_fp=asset_fp)
+    recon_movie_asset = file_path.gen_asset(
+        asset_type=AssetType.REC_MOVIE, asset_fp=asset_fp
+    )
     return recon_movie_asset
 
 
@@ -369,7 +378,9 @@ def consolidate_ave_mrcs(file_path: FilePath) -> dict:
     log_file = f"{file_path.working_dir}/newstack_float.log"
     FilePath.run(cmd=cmd, log_file=log_file)
     asset_fp = file_path.copy_to_assets_dir(fp_to_cp=Path(ave_mrc))
-    ave_vol_asset = file_path.gen_asset(asset_type="averagedVolume", asset_fp=asset_fp)
+    ave_vol_asset = file_path.gen_asset(
+        asset_type=AssetType.AVERAGED_VOLUME, asset_fp=asset_fp
+    )
     return ave_vol_asset
 
 
@@ -386,7 +397,9 @@ def gen_ave_8_vol(file_path: FilePath) -> dict:
     log_file = f"{file_path.working_dir}/ave_8_mrc.log"
     FilePath.run(cmd=cmd, log_file=log_file)
     asset_fp = file_path.copy_to_assets_dir(fp_to_cp=Path(ave_8_mrc))
-    bin_vol_asset = file_path.gen_asset(asset_type="volume", asset_fp=asset_fp)
+    bin_vol_asset = file_path.gen_asset(
+        asset_type=AssetType.VOLUME, asset_fp=asset_fp
+    )
     return bin_vol_asset
 
 

--- a/em_workflows/constants.py
+++ b/em_workflows/constants.py
@@ -1,2 +1,30 @@
+from collections import namedtuple
+
+
 LARGE_DIM = 1024
 SMALL_DIM = 300
+
+# Refer to AssetType.yaml in documentation source for reference
+ASSET_TYPE = namedtuple(
+    "ASSET_TYPE",
+    [
+        "THUMBNAIL",
+        "AVERAGED_VOLUME",
+        "KEY_IMAGE",
+        "REC_MOVIE",
+        "TILT_MOVIE",
+        "VOLUME",
+        "NEUROGLANCER_PRECOMPUTED",
+        "NEUROGLANCER_ZARR",
+    ],
+)
+AssetType = ASSET_TYPE(
+    "thumbnail",
+    "averagedVolume",
+    "keyImage",
+    "recMovie",
+    "tiltMovie",
+    "volume",
+    "neuroglancerPrecomputed",
+    "neuroglancerZarr",
+)

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -8,7 +8,7 @@ from pytools.convert import file_to_uint8
 
 from em_workflows.utils import utils
 from em_workflows.file_path import FilePath
-from em_workflows.constants import LARGE_DIM
+from em_workflows.constants import LARGE_DIM, AssetType
 from .config import DMConfig
 from .constants import LARGE_2D, SMALL_2D, VALID_2D_INPUT_EXTS
 
@@ -138,7 +138,7 @@ def scale_jpegs(file_path: FilePath, size: str) -> Optional[dict]:
     if size.lower() == "s":
         output = file_path.gen_output_fp("_SM.jpeg")
         log = f"{output.parent}/jpeg_sm.log"
-        asset_type = "thumbnail"
+        asset_type = AssetType.THUMBNAIL
         cmd = [
             "gm",
             "convert",
@@ -156,7 +156,7 @@ def scale_jpegs(file_path: FilePath, size: str) -> Optional[dict]:
     elif size.lower() == "l":
         output = file_path.gen_output_fp("_LG.jpeg")
         log = f"{output.parent}/jpeg_lg.log"
-        asset_type = "keyImage"
+        asset_type = AssetType.KEY_IMAGE
         cmd = [
             "gm",
             "convert",

--- a/em_workflows/file_path.py
+++ b/em_workflows/file_path.py
@@ -160,13 +160,12 @@ class FilePath:
         output_fp = f"{self.working_dir.as_posix()}/{f_name}"
         return Path(output_fp)
 
-    def gen_asset(self, asset_type: str, asset_fp: Path) -> Dict:
+    def gen_asset(self, asset_type: str, asset_fp) -> Dict:
         """
         Construct and return an asset (dict) based on the asset "type" and FilePath
         :param asset_type: a string that details the type of output file
         :param asset_fp: the originating FilePath to "hang" the asset on
         :return: the resulting "asset" in the form of a dict
-        TODO: consider changings asset_type to newly created AssetType enum
         """
         assets_fp_no_root = asset_fp.relative_to(self.asset_root)
         asset = {"type": asset_type, "path": assets_fp_no_root.as_posix()}

--- a/em_workflows/lrg_2d_rgb/flow.py
+++ b/em_workflows/lrg_2d_rgb/flow.py
@@ -6,6 +6,7 @@ from prefect.run_configs import LocalRun
 
 from em_workflows.utils import utils
 from em_workflows.file_path import FilePath
+from em_workflows.constants import AssetType
 from .config import LRG2DConfig
 from .constants import (
     LARGE_THUMB_X,
@@ -75,7 +76,9 @@ def bioformats_gen_zarr(file_path: FilePath):
     zarr_image: HedwigZarrImage = zarr_images[list(zarr_images.get_series_keys())[0]]
     zarr_image.rechunk(512)
     asset_fp = file_path.copy_to_assets_dir(fp_to_cp=Path(output_zarr))
-    ng_asset = file_path.gen_asset(asset_type="neuroglancerZarr", asset_fp=asset_fp)
+    ng_asset = file_path.gen_asset(
+        asset_type=AssetType.NEUROGLANCER_ZARR, asset_fp=asset_fp
+    )
     ng_asset["metadata"] = dict(
         shader=zarr_image.shader_type,
         dimensions=zarr_image.dims,
@@ -114,8 +117,12 @@ def gen_thumb(file_path: FilePath):
     )
     asset_fp_sm = file_path.copy_to_assets_dir(fp_to_cp=Path(output_jpeg_sm))
     asset_fp_lg = file_path.copy_to_assets_dir(fp_to_cp=Path(output_jpeg_lg))
-    thumb_asset = file_path.gen_asset(asset_type="thumbnail", asset_fp=asset_fp_sm)
-    keyImage_asset = file_path.gen_asset(asset_type="keyImage", asset_fp=asset_fp_lg)
+    thumb_asset = file_path.gen_asset(
+        asset_type=AssetType.THUMBNAIL, asset_fp=asset_fp_sm
+    )
+    keyImage_asset = file_path.gen_asset(
+        asset_type=AssetType.KEY_IMAGE, asset_fp=asset_fp_lg
+    )
     return [thumb_asset, keyImage_asset]
 
 

--- a/em_workflows/sem_tomo/flow.py
+++ b/em_workflows/sem_tomo/flow.py
@@ -8,6 +8,7 @@ from prefect.run_configs import LocalRun
 
 from em_workflows.utils import utils
 from em_workflows.utils import neuroglancer as ng
+from em_workflows.constants import AssetType
 from .config import SEMConfig
 from .constants import FIBSEM_DEPTH, FIBSEM_HEIGHT, FIBSEM_WIDTH
 
@@ -83,7 +84,9 @@ def gen_newstack_combi(fp_in: FilePath) -> Dict:
     utils.log(f"Created {cmd}")
     FilePath.run(cmd=cmd, log_file=log_file)
     assets_fp_adjusted_mrc = fp_in.copy_to_assets_dir(fp_to_cp=base_mrc)
-    return fp_in.gen_asset(asset_type="averagedVolume", asset_fp=assets_fp_adjusted_mrc)
+    return fp_in.gen_asset(
+        asset_type=AssetType.AVERAGED_VOLUME, asset_fp=assets_fp_adjusted_mrc
+    )
 
 
 @task
@@ -171,7 +174,9 @@ def gen_keyimg(fp_in: FilePath) -> Dict:
     utils.log(f"Created keyimg {cmd}")
     FilePath.run(cmd=cmd, log_file=log_file)
     asset_fp = fp_in.copy_to_assets_dir(fp_to_cp=keyimg_fp)
-    keyimg_asset = fp_in.gen_asset(asset_type="keyImage", asset_fp=asset_fp)
+    keyimg_asset = fp_in.gen_asset(
+        asset_type=AssetType.KEY_IMAGE, asset_fp=asset_fp
+    )
     return keyimg_asset
 
 
@@ -200,7 +205,9 @@ def gen_keyimg_small(fp_in: FilePath) -> Dict:
     utils.log(f"Created {cmd}")
     FilePath.run(cmd=cmd, log_file=log_file)
     asset_fp = fp_in.copy_to_assets_dir(fp_to_cp=keyimg_sm_fp)
-    keyimg_asset = fp_in.gen_asset(asset_type="thumbnail", asset_fp=asset_fp)
+    keyimg_asset = fp_in.gen_asset(
+        asset_type=AssetType.THUMBNAIL, asset_fp=asset_fp
+    )
     return keyimg_asset
 
 
@@ -262,7 +269,7 @@ with Flow(
     corrected_movie_assets = utils.mrc_to_movie.map(
         file_path=fps,
         root=unmapped("adjusted"),
-        asset_type=unmapped("recMovie"),
+        asset_type=unmapped(AssetType.REC_MOVIE),
         upstream_tasks=[base_mrcs],
     )
 

--- a/em_workflows/utils/neuroglancer.py
+++ b/em_workflows/utils/neuroglancer.py
@@ -1,10 +1,11 @@
-from em_workflows.config import Config
-from em_workflows.file_path import FilePath
-from em_workflows.utils import utils
 from typing import Dict
 from pathlib import Path
 from prefect import task
 from pytools.workflow_functions import visual_min_max
+from em_workflows.config import Config
+from em_workflows.file_path import FilePath
+from em_workflows.constants import AssetType
+from em_workflows.utils import utils
 import pytools
 import logging
 import sys
@@ -77,7 +78,9 @@ def gen_zarr(fp_in: FilePath, width: int, height: int, depth: int = None) -> Dic
     pytools.logger.addHandler(handler)
 
     metadata = visual_min_max(mad_scale=5, input_image=first_zarr_arr)
-    ng_asset = fp_in.gen_asset(asset_type="neuroglancerZarr", asset_fp=asset_fp)
+    ng_asset = fp_in.gen_asset(
+        asset_type=AssetType.NEUROGLANCER_ZARR, asset_fp=asset_fp
+    )
 
     ng_asset["metadata"] = metadata
     return ng_asset

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -15,8 +15,9 @@ from prefect.triggers import any_successful, always_run
 from prefect.engine.state import State, Success
 from prefect.engine import signals
 from prefect.engine.signals import SKIP, TRIGGERFAIL
-from em_workflows.config import Config
 from prefect.tasks.control_flow.filter import FilterTask
+
+from em_workflows.config import Config
 from collections import namedtuple
 
 # used for keeping outputs of imod's header command (dimensions of image).
@@ -867,10 +868,6 @@ def gen_fps(share_name: str, input_dir: Path, fps_in: List[Path]) -> List[FilePa
 #         "volume",
 #         "neuroglancerPrecomputed",
 #     ]
-#     if asset_type not in valid_typs:
-#         raise signals.FAIL(
-#             f"Asset type: {asset_type} is not a valid type. {valid_typs}"
-#         )
 #     fp_no_mount_point = path.relative_to(Config.assets_dir(env=get_environment()))
 #     if metadata:
 #         asset = {

--- a/test/test_czi.py
+++ b/test/test_czi.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from em_workflows.file_path import FilePath
 
 
+@pytest.mark.slow
+@pytest.mark.localdata
 def test_input_fname(mock_nfs_mount, caplog):
     from em_workflows.czi.flow import flow
 


### PR DESCRIPTION
Addresses

One of the todos in the code
https://github.com/niaid/image_portal_workflows/blob/main/em_workflows/file_path.py#L170

In a nutshell, asset_types are a set of possible strings. Replacing them by enums removes the possibilities of spelling errors.

### Changes

* asset_type now requires Enums over strings.

### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [ ] tests
