### PR TITLE
Add file_share param into workflows

### DIFF
--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -471,7 +471,6 @@ with Flow(
     terminal_state_handler=utils.custom_terminal_state_handler,
     run_config=LocalRun(labels=[utils.get_environment()]),
 ) as flow:
-
     # This block of params map are for adoc file specfication.
     # Note the ugly names, these parameters are lifted verbatim from
     # https://bio3d.colorado.edu/imod/doc/directives.html where possible.
@@ -489,6 +488,7 @@ with Flow(
 
     adoc_template = Parameter("adoc_template", default="plastic_brt")
     input_dir = Parameter("input_dir")
+    file_share = Parameter("file_share")
     callback_url = Parameter("callback_url", default=None)()
     token = Parameter("token", default=None)()
     file_name = Parameter("file_name", default=None)
@@ -499,13 +499,13 @@ with Flow(
     keep_workdir = Parameter("keep_workdir", default=False)()
 
     # a single input_dir will have n tomograms
-    input_dir_fp = utils.get_input_dir(input_dir=input_dir)
+    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
     # input_dir_fp = utils.get_input_dir(input_dir=input_dir)
     input_fps = utils.list_files(
         input_dir=input_dir_fp, exts=["MRC", "ST", "mrc", "st"], single_file=file_name
     )
 
-    fps = utils.gen_fps(input_dir=input_dir_fp, fps_in=input_fps)
+    fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
     brts = utils.run_brt.map(
         file_path=fps,
         adoc_template=unmapped(adoc_template),

--- a/em_workflows/config.py
+++ b/em_workflows/config.py
@@ -71,8 +71,8 @@ class Config:
     user = os.environ["USER"]
     tmp_dir = f"/gs1/Scratch/{user}_scratch/"
 
-    @classmethod
-    def mount_point(cls, share_name: str) -> str:
+    @staticmethod
+    def mount_point(share_name: str) -> str:
         try:
             share_enum = FileShareEnum[share_name]
         except KeyError as e:

--- a/em_workflows/config.py
+++ b/em_workflows/config.py
@@ -80,16 +80,14 @@ class Config:
                 f"{share_name} is a bad Share name which is not under consideration yet."
             )
             raise e
-        # TODO change the return values as necessary
-        mapper = {
-            FileShareEnum.RMLSOHedwigDev: f"/mnt/ai-fas12-so/{share_name}",
-            FileShareEnum.RMLSOHedwigQA: f"/mnt/ai-fas12-so/{share_name}",
-            FileShareEnum.RMLSOHedwigProd: f"/mnt/ai-fas12-so/{share_name}",
-        }
-        return mapper.get(share_enum, f"/mnt/ai-fas12/{share_name}")
+        return share_enum.get_mount_point()
 
     @staticmethod
     def proj_dir(share_name: str) -> str:
+        """
+        :param share_name: FileShareEnum string
+        :return: Projects folder mount point based on the file-share name
+        """
         return f"{Config.mount_point(share_name)}/Projects/"
 
     @staticmethod

--- a/em_workflows/config.py
+++ b/em_workflows/config.py
@@ -6,6 +6,8 @@ from prefect.executors import DaskExecutor
 import prefect
 import shutil
 
+from em_workflows.enums import FileShareEnum
+
 # loads .env file into os.environ
 load_dotenv()
 
@@ -62,43 +64,37 @@ class Config:
     mrc2tif_loc = os.environ.get("MRC2TIF_LOC", "/opt/rml/imod/bin/mrc2tif")
     newstack_loc = os.environ.get("NEWSTACK_LOC", "/opt/rml/imod/bin/newstack")
 
-    # environment where the app gets run - used for share selection
-    env_to_share = {
-        "dev": "RMLEMHedwigDev",
-        "qa": "RMLEMHedwigQA",
-        "prod": "RMLEMHedwigProd",
-    }
-
     # All settings moved to respective constants file
     # fibsem_input_exts = ["TIFF", "tiff", "TIF", "tif"]
 
     SLURM_EXECUTOR = DaskExecutor(cluster_class=SLURM_exec)
     user = os.environ["USER"]
     tmp_dir = f"/gs1/Scratch/{user}_scratch/"
-    mount_point = "/mnt/ai-fas12/"
 
-    @staticmethod
-    def _share_name(env: str) -> str:
-        """
-        gets the path of the location of input based on environment
-        """
-        val = Config.env_to_share.get(env)
-        if not val:
-            raise ValueError(
-                f"Environment {env} not in valid environments: \
-                    {Config.env_to_share.keys()}"
+    @classmethod
+    def mount_point(cls, share_name: str) -> str:
+        try:
+            share_enum = FileShareEnum[share_name]
+        except KeyError as e:
+            prefect.context.logger.info(
+                f"{share_name} is a bad Share name which is not under consideration yet."
             )
-        return val
+            raise e
+        # TODO change the return values as necessary
+        mapper = {
+            FileShareEnum.RMLSOHedwigDev: f"/mnt/ai-fas12-so/{share_name}",
+            FileShareEnum.RMLSOHedwigQA: f"/mnt/ai-fas12-so/{share_name}",
+            FileShareEnum.RMLSOHedwigProd: f"/mnt/ai-fas12-so/{share_name}",
+        }
+        return mapper.get(share_enum, f"/mnt/ai-fas12/{share_name}")
 
     @staticmethod
-    def proj_dir(env: str) -> str:
-        share = Config._share_name(env=env)
-        return f"{Config.mount_point}{share}/Projects/"
+    def proj_dir(share_name: str) -> str:
+        return f"{Config.mount_point(share_name)}/Projects/"
 
     @staticmethod
-    def assets_dir(env: str) -> str:
-        share = Config._share_name(env=env)
-        return f"{Config.mount_point}{share}/Assets/"
+    def assets_dir(share_name: str) -> str:
+        return f"{Config.mount_point(share_name)}/Assets/"
 
     repo_dir = Path(os.path.dirname(__file__))
     template_dir = Path(f"{repo_dir.as_posix()}/templates")

--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -138,20 +138,21 @@ with Flow(
     run_config=LocalRun(labels=[utils.get_environment()]),
 ) as flow:
     input_dir = Parameter("input_dir")
+    file_share = Parameter("file_share")
     file_name = Parameter("file_name", default=None)
     callback_url = Parameter("callback_url", default=None)()
     token = Parameter("token", default=None)()
     no_api = Parameter("no_api", default=None)()
     # keep workdir if set true, useful to look at outputs
     keep_workdir = Parameter("keep_workdir", default=False)()
-    input_dir_fp = utils.get_input_dir(input_dir=input_dir)
+    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
 
     input_fps = utils.list_files(
         input_dir_fp,
         VALID_CZI_INPUTS,
         single_file=file_name,
     )
-    fps = utils.gen_fps(input_dir=input_dir_fp, fps_in=input_fps)
+    fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
     prim_fps = utils.gen_prim_fps.map(fp_in=fps)
     imageSets = generate_czi_imageset.map(file_path=fps)
     callback_with_zarrs = utils.add_imageSet.map(prim_fp=prim_fps, imageSet=imageSets)

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -227,6 +227,7 @@ with Flow(
     -convert all mrcs in Projects dir to jpegs.
     -convert all tiffs/pngs/jpegs to correct size for thumbs, "sm" and "lg"
     """
+    file_share = Parameter("file_share")
     input_dir = Parameter("input_dir")
     file_name = Parameter("file_name", default=None)
     callback_url = Parameter("callback_url", default=None)()
@@ -234,14 +235,14 @@ with Flow(
     no_api = Parameter("no_api", default=None)()
     # keep workdir if set true, useful to look at outputs
     keep_workdir = Parameter("keep_workdir", default=False)()
-    input_dir_fp = utils.get_input_dir(input_dir=input_dir)
+    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
 
     input_fps = utils.list_files(
         input_dir_fp,
         VALID_2D_INPUT_EXTS,
         single_file=file_name,
     )
-    fps = utils.gen_fps(input_dir=input_dir_fp, fps_in=input_fps)
+    fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
     # logs = utils.init_log.map(file_path=fps)
 
     tiffs_converted = convert_if_int16_tiff.map(file_path=fps)

--- a/em_workflows/enums.py
+++ b/em_workflows/enums.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class FileShareEnum(Enum):
+    """
+    Scientific data can reside in any mounted points depending on the lab or the project.
+    This enum is used to direct where the data is mounted.
+    Source: https://github.com/niaid/hedwig-comm-specs/issues/4#issuecomment-1701512859
+    """
+
+    RMLEMHedwigDev = 1
+    RMLEMHedwigQA = 2
+    RMLEMHedwigProd = 3
+    # SO refers to spatial omics
+    RMLSOHedwigDev = 4
+    RMLSOHedwigQA = 5
+    RMLSOHedwigProd = 6

--- a/em_workflows/enums.py
+++ b/em_workflows/enums.py
@@ -15,3 +15,14 @@ class FileShareEnum(Enum):
     RMLSOHedwigDev = 4
     RMLSOHedwigQA = 5
     RMLSOHedwigProd = 6
+
+    def get_mount_point(self):
+        # TODO change the return values as necessary
+        mapper = {
+            # each of the values might be different
+            FileShareEnum.RMLSOHedwigDev: f"/mnt/ai-fas12-so/{self.name}",
+            FileShareEnum.RMLSOHedwigQA: f"/mnt/ai-fas12-so/{self.name}",
+            FileShareEnum.RMLSOHedwigProd: f"/mnt/ai-fas12-so/{self.name}",
+        }
+        # default
+        return mapper.get(self, f"/mnt/ai-fas12/{self.name}")

--- a/em_workflows/enums.py
+++ b/em_workflows/enums.py
@@ -17,12 +17,12 @@ class FileShareEnum(Enum):
     RMLSOHedwigProd = 6
 
     def get_mount_point(self):
-        # TODO change the return values as necessary
+        # TODO change the return values when decided
         mapper = {
-            # each of the values might be different
-            FileShareEnum.RMLSOHedwigDev: f"/mnt/ai-fas12-so/{self.name}",
-            FileShareEnum.RMLSOHedwigQA: f"/mnt/ai-fas12-so/{self.name}",
-            FileShareEnum.RMLSOHedwigProd: f"/mnt/ai-fas12-so/{self.name}",
+            # each of the values will be different
+            FileShareEnum.RMLSOHedwigDev: "/mnt/ai-fas12/RMLEMHedwigDev",
+            FileShareEnum.RMLSOHedwigQA: "/mnt/ai-fas12/RMLEMHedwigQA",
+            FileShareEnum.RMLSOHedwigProd: "/mnt/ai-fas12/RMLEMHedwigProd",
         }
         # default
         return mapper.get(self, f"/mnt/ai-fas12/{self.name}")

--- a/em_workflows/file_path.py
+++ b/em_workflows/file_path.py
@@ -35,7 +35,7 @@ class FilePath:
     :todo: Consider making entire class immutable
     """
 
-    def __init__(self, input_dir: Path, fp_in: Path) -> None:
+    def __init__(self, share_name: str, input_dir: Path, fp_in: Path) -> None:
         """
         sets up:
 
@@ -51,10 +51,9 @@ class FilePath:
         self._working_dir = self.make_work_dir()
         self._assets_dir = self.make_assets_dir()
         self.environment = self.get_environment()
-        self.proj_root = Path(Config.proj_dir(env=self.environment))
-        self.asset_root = Path(Config.assets_dir(env=self.environment))
+        self.proj_root = Path(Config.proj_dir(share_name=share_name))
+        self.asset_root = Path(Config.assets_dir(share_name=share_name))
         self.prim_fp_elt = self.gen_prim_fp_elt()
-        # log(self.__repr__())
 
     def __str__(self) -> str:
         return f"FilePath: proj_root:{self.proj_root}\n\

--- a/em_workflows/lrg_2d_rgb/flow.py
+++ b/em_workflows/lrg_2d_rgb/flow.py
@@ -130,20 +130,21 @@ with Flow(
     -create tmp dir for each.
     -convert to tiff -> zarr -> jpegs (thumb)
     """
+    file_share = Parameter("file_share")
     input_dir = Parameter("input_dir")
     file_name = Parameter("file_name", default=None)
     callback_url = Parameter("callback_url", default=None)()
     token = Parameter("token", default=None)()
     no_api = Parameter("no_api", default=None)()
     keep_workdir = Parameter("keep_workdir", default=False)()
-    input_dir_fp = utils.get_input_dir(input_dir=input_dir)
+    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
 
     input_fps = utils.list_files(
         input_dir_fp,
         VALID_LRG_2D_RGB_INPUTS,
         single_file=file_name,
     )
-    fps = utils.gen_fps(input_dir=input_dir_fp, fps_in=input_fps)
+    fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
     tiffs = convert_png_to_tiff.map(file_path=fps)
     zarr_assets = bioformats_gen_zarr.map(file_path=fps, upstream_tasks=[tiffs])
     thumb_assets = gen_thumb.map(file_path=fps, upstream_tasks=[zarr_assets])

--- a/em_workflows/sem_tomo/flow.py
+++ b/em_workflows/sem_tomo/flow.py
@@ -227,6 +227,7 @@ with Flow(
     - Firstly create nifti file using the base mrc, then convert this to ng format.
     - To conclude, send callback stating the location of the various outputs.
     """
+    file_share = Parameter("file_share")
     input_dir = Parameter("input_dir")
     file_name = Parameter("file_name", default=None)
     callback_url = Parameter("callback_url", default=None)()
@@ -237,13 +238,15 @@ with Flow(
     keep_workdir = Parameter("keep_workdir", default=False)()
 
     # dir to read from.
-    input_dir_fp = utils.get_input_dir(input_dir=input_dir)
+    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
     # note FIBSEM is different to other flows in that it uses *directories*
     # to define stacks. Therefore, will have to list dirs to discover stacks
     # (rather than eg mrc files)
     input_dir_fps = utils.list_dirs(input_dir_fp=input_dir_fp)
 
-    fps = utils.gen_fps(input_dir=input_dir_fp, fps_in=input_dir_fps)
+    fps = utils.gen_fps(
+        share_name=file_share, input_dir=input_dir_fp, fps_in=input_dir_fps
+    )
     tif_to_mrc = convert_tif_to_mrc.map(fps)
 
     # using source.mrc gen align.xf

--- a/em_workflows/utils/neuroglancer.py
+++ b/em_workflows/utils/neuroglancer.py
@@ -12,7 +12,6 @@ import sys
 
 @task
 def gen_zarr(fp_in: FilePath, width: int, height: int, depth: int = None) -> Dict:
-
     """
     .. code-block::
 

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -786,7 +786,7 @@ def get_environment() -> str:
 
 
 @task
-def get_input_dir(input_dir: str) -> Path:
+def get_input_dir(share_name: str, input_dir: str) -> Path:
     """
     :param input_dir:
     :return:
@@ -801,12 +801,12 @@ def get_input_dir(input_dir: str) -> Path:
         input_dir = input_dir + "/"
     if not input_dir.startswith("/"):
         input_dir = "/" + input_dir
-    input_path_str = Config.proj_dir(env=get_environment()) + input_dir
+    input_path_str = Config.proj_dir(share_name=share_name) + input_dir
     return Path(input_path_str)
 
 
 @task
-def gen_fps(input_dir: Path, fps_in: List[Path]) -> List[FilePath]:
+def gen_fps(share_name: str, input_dir: Path, fps_in: List[Path]) -> List[FilePath]:
     """
     Given in input directory (Path) and a list of input files (Path), return
     a list of FilePaths for the input files. This includes a temporary working
@@ -814,7 +814,7 @@ def gen_fps(input_dir: Path, fps_in: List[Path]) -> List[FilePath]:
     """
     fps = list()
     for fp in fps_in:
-        file_path = FilePath(input_dir=input_dir, fp_in=fp)
+        file_path = FilePath(share_name=share_name, input_dir=input_dir, fp_in=fp)
         msg = f"created working_dir {file_path.working_dir} for {fp.as_posix()}"
         log(msg)
         fps.append(file_path)

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -788,14 +788,14 @@ def get_environment() -> str:
 @task
 def get_input_dir(share_name: str, input_dir: str) -> Path:
     """
+    :param share_name:
     :param input_dir:
-    :return:
+    :return: Path to complete project directory (obtained from share-name)
+        combined with relative input directory
 
     | Concat the POSTed input file path to the mount point.
     | create working dir
-    | set up logger
     | returns Path obj
-
     """
     if not input_dir.endswith("/"):
         input_dir = input_dir + "/"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,10 +17,10 @@ def mock_nfs_mount(monkeypatch):
     from em_workflows.dm_conversion.config import DMConfig
     from em_workflows.sem_tomo.config import SEMConfig
 
-    def _mock_proj_dir(env: str) -> str:
+    def _mock_proj_dir(share_name: str) -> str:
         return os.getcwd()
 
-    def _mock_assets_dir(env: str) -> str:
+    def _mock_assets_dir(share_name: str) -> str:
         return os.getcwd()
 
     monkeypatch.setattr(Config, "proj_dir", _mock_proj_dir)

--- a/test/test_brt.py
+++ b/test/test_brt.py
@@ -23,6 +23,7 @@ def test_brt(mock_nfs_mount):
         TargetNumberOfBeads=20,
         LocalAlignments=0,
         THICKNESS=30,
+        file_share="test",
         input_dir="test/input_files/brt_inputs/Projects/",
         no_api=True,
         keep_workdir=True,

--- a/test/test_czi.py
+++ b/test/test_czi.py
@@ -7,6 +7,7 @@ def test_input_fname(mock_nfs_mount, caplog):
     from em_workflows.czi.flow import flow
 
     state = flow.run(
+        file_share="test",
         input_dir="test/input_files/IF_czi/Projects/smaller",
         no_api=True,
     )
@@ -17,12 +18,12 @@ def test_rechunk(mock_nfs_mount, caplog):
     from em_workflows.czi.flow import gen_imageSet
 
     input_dir = Path(
-        "/gs1/home/hedwig_dev/image_portal_workflows/image_portal_workflows/test/input_files/IF_czi/Projects/zarr_dir_2/"
+        "/gs1/home/hedwig_dev/image_portal_workflows/image_portal_workflows/test/input_files/IF_czi/Projects/zarr_dir_2/"  # noqa: E501
     )
     fp_in = Path(
-        "/gs1/home/hedwig_dev/image_portal_workflows/image_portal_workflows/test/input_files/IF_czi/Projects/zarr_dir_2/"
+        "/gs1/home/hedwig_dev/image_portal_workflows/image_portal_workflows/test/input_files/IF_czi/Projects/zarr_dir_2/"  # noqa: E501
     )
-    fp = FilePath(input_dir=input_dir, fp_in=fp_in)
+    fp = FilePath(share_name="test", input_dir=input_dir, fp_in=fp_in)
     d = shutil.copytree(fp_in.as_posix(), f"{fp.working_dir.as_posix()}/{fp_in.name}")
     print(d)
     zars = gen_imageSet(fp)

--- a/test/test_czi.py
+++ b/test/test_czi.py
@@ -1,3 +1,4 @@
+import pytest
 import shutil
 from pathlib import Path
 from em_workflows.file_path import FilePath
@@ -14,6 +15,7 @@ def test_input_fname(mock_nfs_mount, caplog):
     assert state.is_successful()
 
 
+@pytest.mark.skip(reason="input dirs need to be put in place properly.")
 def test_rechunk(mock_nfs_mount, caplog):
     from em_workflows.czi.flow import gen_imageSet
 

--- a/test/test_dm.py
+++ b/test/test_dm.py
@@ -11,6 +11,7 @@ def test_dm4_conv(mock_nfs_mount):
     from em_workflows.dm_conversion.flow import flow
 
     state = flow.run(
+        file_share="test",
         input_dir="/test/input_files/dm_inputs/Projects/Lab/PI",
         no_api=True,
     )
@@ -21,6 +22,7 @@ def test_dm4_conv_clean_workdir(mock_nfs_mount):
     from em_workflows.dm_conversion.flow import flow
 
     state = flow.run(
+        file_share="test",
         input_dir="/test/input_files/dm_inputs/Projects/Lab/PI",
         no_api=True,
         # keep_workdir=True
@@ -32,6 +34,7 @@ def test_input_fname(mock_nfs_mount):
     from em_workflows.dm_conversion.flow import flow
 
     state = flow.run(
+        file_share="test",
         input_dir="/test/input_files/dm_inputs/Projects/Lab/PI",
         file_name="20210525_1416_A000_G000.dm4",
         no_api=True,
@@ -44,6 +47,7 @@ def test_single_file_no_ext_not_found_gens_exception(mock_nfs_mount):
     from em_workflows.dm_conversion.flow import flow
 
     state = flow.run(
+        file_share="test",
         input_dir="/test/input_files/dm_inputs/Projects/Lab/PI",
         file_name="file_with_no_ext",
         no_api=True,
@@ -56,6 +60,7 @@ def test_single_file_not_found_gens_exception(mock_nfs_mount):
     from em_workflows.dm_conversion.flow import flow
 
     state = flow.run(
+        file_share="test",
         input_dir="/test/input_files/dm_inputs/Projects/Lab/PI",
         file_name="does_not_exist.test",
         no_api=True,

--- a/test/test_lrg_2d.py
+++ b/test/test_lrg_2d.py
@@ -4,6 +4,7 @@ def test_input_fname(mock_nfs_mount, caplog):
     # monkeypatch.setattr(Config, "convert_loc", command_loc("convert"))
 
     state = flow.run(
+        file_share="test",
         input_dir="/test/input_files/lrg_ROI_pngs/Projects",
         no_api=True,
     )

--- a/test/test_sem.py
+++ b/test/test_sem.py
@@ -8,6 +8,7 @@ def test_sem(mock_nfs_mount):
 
     result = flow.run(
         # FIXME `sem_inputs` directory is missing
+        file_share="test",
         input_dir="/test/input_files/sem_inputs/Projects/",
         tilt_angle="30.2",
         no_api=True,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -8,6 +8,7 @@ import tempfile
 from em_workflows.utils import utils
 from em_workflows.file_path import FilePath
 from em_workflows.config import Config
+from em_workflows.enums import FileShareEnum
 from em_workflows.brt.config import BRTConfig
 from em_workflows.dm_conversion.config import DMConfig
 from em_workflows.sem_tomo.config import SEMConfig
@@ -81,23 +82,23 @@ def test_mount_config(mock_nfs_mount):
     assert os.path.exists(SEMConfig.xftoxg_loc)
 
 
-def test_share_name(mock_nfs_mount):
+def test_mount_point():
     """
-    Check the share mapping
+    Check mount point is retrieved properly
     """
-    env = utils.get_environment()
-    assert env.lower() in Config._share_name(env).lower()
-    assert "rmlemhedwig" in Config._share_name(env).lower()
+    share_enum = FileShareEnum.RMLEMHedwigDev
+    mnt_point = Config.mount_point(share_name=share_enum.name)
+    assert mnt_point == share_enum.get_mount_point()
 
 
-def test_bad_share_name(mock_nfs_mount):
+def test_bad_mount_point():
     """
     Verify that bad or non-existant value raises error
     """
-    with pytest.raises(Exception):
-        Config._share_name("BAD")
-    with pytest.raises(Exception):
-        Config._share_name(None)
+    with pytest.raises(KeyError):
+        Config.mount_point("BAD")
+    with pytest.raises(KeyError):
+        Config.mount_point(None)
 
 
 def test_lookup_dims(mock_nfs_mount):
@@ -138,9 +139,11 @@ def test_bad_lookup_dims(mock_nfs_mount):
 
 
 def test_get_input_dir(mock_nfs_mount):
-    utils.get_environment()
+    share_name = FileShareEnum.RMLSOHedwigDev.name
     input_dir = "/test/input_files/dm_inputs"
-    my_path = utils.get_input_dir.__wrapped__(input_dir=input_dir)
+    my_path = utils.get_input_dir.__wrapped__(
+        share_name=share_name, input_dir=input_dir
+    )
     assert "image_portal_workflows" in str(my_path)
     assert input_dir in str(my_path)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -52,12 +52,11 @@ def test_mount_config(mock_nfs_mount):
     Limited checks of Config constants
     :todo: Rewrite using @pytest.mark.parametrize to limit repetition
     """
-    env = utils.get_environment()
-    proj_dir = Config.proj_dir(env=env)
+    proj_dir = Config.proj_dir("test")
     assert "image_portal_workflows" in proj_dir
     #    assert env in proj_dir    # Not true in GitHub Actions test
 
-    assets_dir = Config.assets_dir(env=env)
+    assets_dir = Config.assets_dir(share_name="/mocked")
     assert "image_portal_workflows" in assets_dir
     #    assert env in assets_dir    # Not true in GitHub Actions test
 
@@ -106,7 +105,7 @@ def test_lookup_dims(mock_nfs_mount):
     Test on a number of different file types
     :todo: Consider rewriting this test to use @pytest.mark.parametrize to limit repetition
     """
-    proj_dir = Config.proj_dir(utils.get_environment())
+    proj_dir = Config.proj_dir("test")
     input_dir = "test/input_files/dm_inputs/Projects/Lab/PI/"
     image_path = Path(os.path.join(proj_dir, input_dir, "1-As-70-007.tif"))
     dims = utils.lookup_dims(fp=image_path)
@@ -127,7 +126,7 @@ def test_bad_lookup_dims(mock_nfs_mount):
     """
     This test should fail ``header`` doesn't work on PNG
     """
-    proj_dir = Config.proj_dir(utils.get_environment())
+    proj_dir = Config.proj_dir("test")
     input_dir = "test/input_files/dm_inputs/Projects/Lab/PI/"
     # Error case - PNG not valid input
     image_path = Path(
@@ -239,7 +238,7 @@ def test_mrc_to_movie(mock_nfs_mount):
     :todo: Determine method for storing test data; smaller test images would be helpful
     as current mrc is 1.5 GB.
     """
-    proj_dir = Config.proj_dir(utils.get_environment())
+    proj_dir = Config.proj_dir("test")
     input_dir = "test/input_files/sem_inputs/Projects/mrc_movie_test"
     input_path = Path(os.path.join(proj_dir, input_dir))
     # FIXME input directory `sem_inputs` in test/input_files is missing
@@ -248,7 +247,7 @@ def test_mrc_to_movie(mock_nfs_mount):
     image_path = Path(os.path.join(proj_dir, input_dir, "adjusted.mrc"))
     assert image_path.exists()
 
-    mrc_filepath = FilePath(input_dir=input_path, fp_in=image_path)
+    mrc_filepath = FilePath(share_name="Test", input_dir=input_path, fp_in=image_path)
     shutil.copy(image_path, mrc_filepath.working_dir)
 
     #    mrc_list = utils.gen_fps.__wrapped__(input_path, [image_path])
@@ -284,14 +283,14 @@ def test_copy_workdirs_small(mock_nfs_mount):
     """
     Tests that the workdir is copied to the assets dir. This uses toy data only.
     """
-    proj_dir = Config.proj_dir(utils.get_environment())
+    proj_dir = Config.proj_dir("test")
     test_dir = "test/input_files/dm_inputs/Projects/Lab/PI/"
     test_image = "P6_J130_fsc_iteration_001.png"
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         input_path = Path(tmp_dir) / "Projects"
         image_path = Path(proj_dir) / test_dir / test_image
-        image_filepath = FilePath(input_dir=input_path, fp_in=image_path)
+        image_filepath = FilePath(share_name="", input_dir=input_path, fp_in=image_path)
         shutil.copy(image_path, image_filepath.working_dir)
 
         workdest = utils.copy_workdirs.__wrapped__(image_filepath)


### PR DESCRIPTION
Addresses
- https://github.com/niaid/hedwig-comm-specs/issues/4#issuecomment-1701512859
- https://github.com/niaid/image_portal_workflows/issues/295
- https://github.com/niaid/image_portal_workflows/issues/296

### Changes

* Uses a mapper over `env`
* FilePath initialization requires `share_name` argument (previously not required)
* Config. `proj_dir` and `assets_dir` requires `share_name` argument (previously relied on env)

### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [ ] tests
