### PR TITLE
Adding new IF czi workflow

### DIFF
--- a/em_workflows/czi/constants.py
+++ b/em_workflows/czi/constants.py
@@ -1,1 +1,15 @@
+from os import cpu_count
+
 VALID_CZI_INPUTS = ["czi", "CZI"]
+RECHUNK_SIZE = 512
+SITK_COMPRESSION_LVL = 90
+THUMB_X_DIM = 300
+THUMB_Y_DUM = 300
+
+# at 20 we're seeing drop off in perf increases on HPC, tune this over time.
+if cpu_count() is None:
+    BIOFORMATS_NUM_WORKERS = 1
+elif cpu_count() - 2 > 20:
+    BIOFORMATS_NUM_WORKERS = 20
+else:
+    BIOFORMATS_NUM_WORKERS = cpu_count() - 2

--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -1,15 +1,72 @@
 from pathlib import Path
+from typing import List, Dict
+import SimpleITK as sitk
 from prefect import Flow, Parameter, task
+from pytools.HedwigZarrImage import HedwigZarrImage
+from pytools.HedwigZarrImages import HedwigZarrImages
 from em_workflows.file_path import FilePath
 from em_workflows.utils import utils
-from em_workflows.config import Config
 from prefect.run_configs import LocalRun
 from .constants import VALID_CZI_INPUTS
+from .config import CZIConfig
+
+
+def rechunk_zarr(zarr_fp: Path) -> None:
+    images = HedwigZarrImages(zarr_fp, read_only=False)
+    for _, image in images.series():
+        image.rechunk(512)  # config.CHUNK_SIZE
+
+
+def gen_thumb(image: HedwigZarrImage, file_path: FilePath) -> dict:
+    sitk_image = image.extract_2d(target_size_x=300, target_size_y=300, auto_uint8=True)
+    if sitk_image:
+        output_jpeg = f"{file_path.working_dir}/{file_path.base}_sm.jpeg"
+        sitk.WriteImage(
+            sitk_image,
+            output_jpeg,
+            useCompression=True,
+            compressionLevel=90,
+        )
+        asset_fp = file_path.copy_to_assets_dir(fp_to_cp=Path(output_jpeg))
+        thumb_asset = file_path.gen_asset(asset_type="thumbnail", asset_fp=asset_fp)
+        return thumb_asset
+
+
+def gen_imageSet(file_path: FilePath) -> List:
+
+    zarr_fp = f"{file_path.assets_dir}/{file_path.base}.zarr"
+    imageSet = list()
+    zarrImages = HedwigZarrImages(Path(zarr_fp))
+    for image_name, image in zarrImages.series():
+        # single image element
+        image_elt = dict()
+        image_elt["imageMetadata"] = None
+        assets = list()
+        if image_name == "macro image":
+            # we don't care about the macro image
+            continue
+        assets.append(gen_thumb(image=image, file_path=file_path))
+        image_elt["imageName"] = image_name
+
+        if image_name != "label image":
+            ng_asset = file_path.gen_asset(
+                asset_type="neuroglancerZarr", asset_fp=Path(zarr_fp)
+            )
+            ng_asset["metadata"] = dict(
+                shader=image.shader_type,
+                dimensions=image.dims,
+                shaderParameters=image.neuroglancer_shader_parameters(),
+            )
+            assets.append(ng_asset)
+        image_elt["assets"] = assets
+        imageSet.append(image_elt)
+    return imageSet
 
 
 @task
 def bioformats_gen_zarr(file_path: FilePath):
     """
+    TODO sort ot the num workers
     TODO, refactor this into ng.gen_zarr
     bioformats2raw --max_workers=$nproc  --downsample-type AREA
     --compression=blosc --compression-properties cname=zstd
@@ -17,12 +74,12 @@ def bioformats_gen_zarr(file_path: FilePath):
     input.tiff output.zarr
     """
 
-    input_czi = f"{file_path.working_dir}/{file_path.base}.czi"
+    input_czi = f"{file_path.proj_dir}/{file_path.base}.czi"
     output_zarr = f"{file_path.working_dir}/{file_path.base}.zarr"
     log_fp = f"{file_path.working_dir}/{file_path.base}_as_zarr.log"
     cmd = [
-        Config.bioformats2raw,
-        "--max_workers=8",
+        CZIConfig.bioformats2raw,
+        "--max_workers=19",
         "--overwrite",
         "--downsample-type",
         "AREA",
@@ -37,18 +94,26 @@ def bioformats_gen_zarr(file_path: FilePath):
         output_zarr,
     ]
     FilePath.run(cmd, log_fp)
-    cmd = ["zarr_rechunk", "--chunk-size", "512", output_zarr]
-    log_fp = f"{file_path.working_dir}/{file_path.base}_rechunk.log"
-    FilePath.run(cmd, log_fp)
-    asset_fp = file_path.copy_to_assets_dir(fp_to_cp=Path(output_zarr))
-    ng_asset = file_path.gen_asset(asset_type="neuroglancerZarr", asset_fp=asset_fp)
-    return ng_asset
+    rechunk_zarr(zarr_fp=Path(output_zarr))
+    file_path.copy_to_assets_dir(fp_to_cp=Path(output_zarr))
+    imageSet = gen_imageSet(file_path=file_path)
+    # extract images from input file, used to create imageSet elements
+    return imageSet
+
+
+@task
+def find_thumb_idx(callback: List[Dict]) -> List[Dict]:
+    for elt in callback:
+        for i, image_elt in enumerate(elt["imageSet"]):
+            if image_elt["imageName"] == "label image":
+                elt["thumbnailIndex"] = i
+    return callback
 
 
 with Flow(
     "czi_to_zarr",
     state_handlers=[utils.notify_api_completion, utils.notify_api_running],
-    executor=Config.SLURM_EXECUTOR,
+    executor=CZIConfig.SLURM_EXECUTOR,
     run_config=LocalRun(labels=[utils.get_environment()]),
 ) as flow:
 
@@ -67,3 +132,12 @@ with Flow(
         single_file=file_name,
     )
     fps = utils.gen_fps(input_dir=input_dir_fp, fps_in=input_fps)
+    prim_fps = utils.gen_prim_fps.map(fp_in=fps)
+    imageSets = bioformats_gen_zarr.map(file_path=fps)
+    callback_with_zarrs = utils.add_imageSet.map(prim_fp=prim_fps, imageSet=imageSets)
+    callback_with_zarrs = find_thumb_idx(callback=callback_with_zarrs)
+    filtered_callback = utils.filter_results(callback_with_zarrs)
+    cb = utils.send_callback_body(
+        token=token, callback_url=callback_url, files_elts=filtered_callback
+    )
+    rm_workdirs = utils.cleanup_workdir(fps, upstream_tasks=[cb])

--- a/em_workflows/file_path.py
+++ b/em_workflows/file_path.py
@@ -161,7 +161,7 @@ class FilePath:
         output_fp = f"{self.working_dir.as_posix()}/{f_name}"
         return Path(output_fp)
 
-    def gen_asset(self, asset_type: str, asset_fp) -> Dict:
+    def gen_asset(self, asset_type: str, asset_fp: Path) -> Dict:
         """
         Construct and return an asset (dict) based on the asset "type" and FilePath
         :param asset_type: a string that details the type of output file

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -115,7 +115,18 @@ def gen_prim_fps(fp_in: FilePath) -> Dict:
 
 
 @task
-def add_asset(prim_fp: dict, asset: dict) -> dict:
+def add_imageSet(prim_fp: dict, imageSet: list) -> Dict:
+    """
+    :param prim_fp: the 'primary' element, describing input file location
+    :param imageSet: list of scenes
+    :return: prim_fp with asset added
+    """
+    prim_fp["imageSet"] = imageSet
+    return prim_fp
+
+
+@task
+def add_asset(prim_fp: dict, asset: dict, image_idx: int = None) -> dict:
     """
     :param prim_fp: the 'primary' element (dict) to which assets are appended
     :param asset: The actual asset (output) to be added in the form of another dict
@@ -144,13 +155,14 @@ def add_asset(prim_fp: dict, asset: dict) -> dict:
     funtional style avoids this. This is why the callback data structure is not built inside
     the FilePath object at runtime.
     """
-    # TODO - at the moment we're assuming there's only a single image per file.
-    # when czi is implmented, we should pass which imageset to use.
+
+    if not image_idx:
+        image_idx = 0
     if type(asset) is list:
-        prim_fp["imageSet"][0]["assets"].extend(asset)
+        prim_fp["imageSet"][image_idx]["assets"].extend(asset)
     else:
-        prim_fp["imageSet"][0]["assets"].append(asset)
-    log(f"Added fp elt {asset} to {prim_fp}.")
+        prim_fp["imageSet"][image_idx]["assets"].append(asset)
+    log(f"Added fp elt {asset} to {prim_fp}, at index {image_idx}.")
     return prim_fp
 
 

--- a/test/test_czi.py
+++ b/test/test_czi.py
@@ -1,0 +1,29 @@
+import shutil
+from pathlib import Path
+from em_workflows.file_path import FilePath
+
+
+def test_input_fname(mock_nfs_mount, caplog):
+    from em_workflows.czi.flow import flow
+
+    state = flow.run(
+        input_dir="test/input_files/IF_czi/Projects/smaller",
+        no_api=True,
+    )
+    assert state.is_successful()
+
+
+def test_rechunk(mock_nfs_mount, caplog):
+    from em_workflows.czi.flow import gen_imageSet
+
+    input_dir = Path(
+        "/gs1/home/hedwig_dev/image_portal_workflows/image_portal_workflows/test/input_files/IF_czi/Projects/zarr_dir_2/"
+    )
+    fp_in = Path(
+        "/gs1/home/hedwig_dev/image_portal_workflows/image_portal_workflows/test/input_files/IF_czi/Projects/zarr_dir_2/"
+    )
+    fp = FilePath(input_dir=input_dir, fp_in=fp_in)
+    d = shutil.copytree(fp_in.as_posix(), f"{fp.working_dir.as_posix()}/{fp_in.name}")
+    print(d)
+    zars = gen_imageSet(fp)
+    print(zars)


### PR DESCRIPTION
Addresses - https://github.com/niaid/image_portal_workflows/discussions/227

### Changes

* Adds workflow to convert `czi` image data
* Workflow now uses `pytools.HedwigZarrImage` object for zarr manipulation
* Breaking Change - the callback data structure ( the new structure has been merged https://github.com/niaid/image_portal_workflows/pull/274 and it will be reflected on this workflow callback)

### This PR doesn't introduce any:

- [ ] Binary files
- [ ] Temporary files, auto-generated files
- [ ] Secret keys
- [ ] Local debugging `print` statements
- [ ] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [ ] tests
