### PR TITLE
Test callback structure

### DIFF
--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -948,29 +948,7 @@ def send_callback_body(
     the body of the callback should look something like this:
 
     .. code-block::
-
-        {
-            "status": "success",
-            "files":
-            [
-                {
-                    "primaryFilePath: "Lab/PI/Myproject/MySession/Sample1/file_a.dm4",
-                    "title": "file_a",
-                    "assets":
-                    [
-                        {
-                            "type": "keyImage",
-                            "path": "Lab/PI/Myproject/MySession/Sample1/file_a.jpg"
-                        },
-                        {
-                            "type": "thumbnail",
-                            "path": "Lab/PI/Myproject/MySession/Sample1/file_a_s.jpg"
-                        }
-                    ]
-                }
-            ]
-        }
-
+        Refer to docs/demo_callback.json for expected
     """
     data = {"files": files_elts}
     if prefect.context.parameters.get("no_api"):

--- a/test/test_czi.py
+++ b/test/test_czi.py
@@ -1,6 +1,8 @@
-import pytest
+import json
+import os
 import shutil
 from pathlib import Path
+import pytest
 from em_workflows.file_path import FilePath
 
 
@@ -53,3 +55,89 @@ def test_no_mount_point_flow_fails(mock_binaries, monkeypatch, caplog):
     )
     assert not state.is_successful()
     assert f"{share_name} doesn't exist. Failing!" in caplog.text, caplog.text
+
+
+@pytest.fixture
+def mock_reuse_zarr(monkeypatch):
+    """
+    Reuses zarr generated from bioformats2raw
+    One of the most expensive operation in tests is using bf2raw command
+    This test assumes that we have already ran the test once. If the .zarr
+    converted file is found, reuses the file without re-executing bf2raw command
+    """
+    from em_workflows.czi import flow
+
+    def _mock_bioformats_gen_zarr(file_path: FilePath):
+        zarr_fp = f"{file_path.assets_dir}/{file_path.base}.zarr"
+        if Path(zarr_fp).exists():
+            return
+        flow.bioformats_gen_zarr(file_path)
+
+    monkeypatch.setattr(flow, "bioformats_gen_zarr", _mock_bioformats_gen_zarr)
+
+
+def test_czi_workflow_callback_structure(
+    mock_nfs_mount, caplog, mock_reuse_zarr, mock_callback_data
+):
+    """
+    Tests that appropriate structure exists in the callback output
+    Tests that there is no duplication in the callback output
+    """
+    from em_workflows.czi.flow import flow
+
+    input_dir = "test/input_files/IF_czi/Projects/smaller"
+    state = flow.run(
+        input_dir=input_dir,
+        no_api=True,
+    )
+    assert state.is_successful()
+
+    callback_output = {}
+    with open(mock_callback_data) as fd:
+        callback_output = json.load(fd)
+
+    # Belwo, assert possible structures and data sanitation checks
+    assert "files" in callback_output
+    # .czi files and length of the callback.files is equal
+    assert len(
+        [item for item in os.listdir(input_dir) if item.endswith(".czi")]
+    ) == len(callback_output["files"])
+
+    first = callback_output["files"][0]
+    # look at the structure of the result
+    assert "primaryFilePath" in first
+    assert "title" in first
+    assert "thumbnailIndex" in first and first["thumbnailIndex"] >= 0
+    assert "imageSet" in first and isinstance(first["imageSet"], list)
+    assert (
+        len(first["imageSet"]) > 1
+    ), "One label image and atleast one scene image should exist"
+    scene_elements = [
+        img for img in first["imageSet"] if img["imageName"] != "label image"
+    ]
+
+    # scene structures
+    first_scene = scene_elements[0]
+    assert "imageName" in first_scene
+    assert (
+        len(first_scene["assets"]) == 2
+    ), "One thumbnail and one zarr file should have existed"
+    assets = first_scene["assets"]
+    assert sorted([assets[0]["type"], assets[1]["type"]]) == [
+        "neuroglancerZarr",
+        "thumbnail",
+    ]
+    nzarr = [asset for asset in assets if asset["type"] == "neuroglancerZarr"][0]
+    assert "path" in nzarr
+    assert (
+        nzarr["path"] != first["primaryFilePath"]
+    ), "The neuroglancer group path should be different from root path"
+
+    label_element = [
+        img for img in first["imageSet"] if img["imageName"] == "label image"
+    ]
+    # label related checks
+    assert len(label_element) == 1, "Only one label image was expected"
+    label_element = label_element[0]
+    assert len(label_element["assets"]) == 1
+    assert label_element["assets"][0]["type"] == "thumbnail"


### PR DESCRIPTION
### Changes

* Mocks bioformats2raw (expensive command) to check if zarr has already been created
* Stores callback from workflows in temporary file so that data can be checked (example in test_czi.py)

### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [x] tests
