### PR TITLE
Use workers count wherever bf2raw command is used

### DIFF
--- a/em_workflows/constants.py
+++ b/em_workflows/constants.py
@@ -1,8 +1,16 @@
+from os import cpu_count
 from collections import namedtuple
-
 
 LARGE_DIM = 1024
 SMALL_DIM = 300
+
+# at 20 we're seeing drop off in perf increases on HPC, tune this over time.
+if cpu_count() is None:
+    BIOFORMATS_NUM_WORKERS = 1
+elif cpu_count() - 2 > 20:
+    BIOFORMATS_NUM_WORKERS = 20
+else:
+    BIOFORMATS_NUM_WORKERS = cpu_count() - 2
 
 # Refer to AssetType.yaml in documentation source for reference
 ASSET_TYPE = namedtuple(

--- a/em_workflows/czi/constants.py
+++ b/em_workflows/czi/constants.py
@@ -1,15 +1,5 @@
-from os import cpu_count
-
 VALID_CZI_INPUTS = ["czi", "CZI"]
 RECHUNK_SIZE = 512
 SITK_COMPRESSION_LVL = 90
 THUMB_X_DIM = 300
 THUMB_Y_DUM = 300
-
-# at 20 we're seeing drop off in perf increases on HPC, tune this over time.
-if cpu_count() is None:
-    BIOFORMATS_NUM_WORKERS = 1
-elif cpu_count() - 2 > 20:
-    BIOFORMATS_NUM_WORKERS = 20
-else:
-    BIOFORMATS_NUM_WORKERS = cpu_count() - 2

--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -7,8 +7,8 @@ from pytools.HedwigZarrImages import HedwigZarrImages
 from em_workflows.file_path import FilePath
 from em_workflows.utils import utils
 from prefect.run_configs import LocalRun
+from em_workflows.constants import BIOFORMATS_NUM_WORKERS
 from em_workflows.czi.constants import (
-    BIOFORMATS_NUM_WORKERS,
     RECHUNK_SIZE,
     VALID_CZI_INPUTS,
     THUMB_X_DIM,

--- a/em_workflows/lrg_2d_rgb/flow.py
+++ b/em_workflows/lrg_2d_rgb/flow.py
@@ -6,7 +6,7 @@ from prefect.run_configs import LocalRun
 
 from em_workflows.utils import utils
 from em_workflows.file_path import FilePath
-from em_workflows.constants import AssetType
+from em_workflows.constants import AssetType, BIOFORMATS_NUM_WORKERS
 from em_workflows.lrg_2d_rgb.config import LRG2DConfig
 from em_workflows.lrg_2d_rgb.constants import (
     LARGE_THUMB_X,
@@ -56,6 +56,7 @@ def bioformats_gen_zarr(file_path: FilePath):
     log_fp = f"{file_path.working_dir}/{file_path.base}_as_zarr.log"
     cmd = [
         LRG2DConfig.bioformats2raw,
+        f"--max_workers={BIOFORMATS_NUM_WORKERS}",
         "--overwrite",
         "--scale-format-string",
         "%2$d",

--- a/em_workflows/utils/neuroglancer.py
+++ b/em_workflows/utils/neuroglancer.py
@@ -4,7 +4,7 @@ from prefect import task
 from pytools.workflow_functions import visual_min_max
 from em_workflows.config import Config
 from em_workflows.file_path import FilePath
-from em_workflows.constants import AssetType
+from em_workflows.constants import AssetType, BIOFORMATS_NUM_WORKERS
 from em_workflows.utils import utils
 import pytools
 import logging
@@ -37,6 +37,7 @@ def gen_zarr(fp_in: FilePath, width: int, height: int, depth: int = None) -> Dic
 
     cmd = [
         Config.bioformats2raw,
+        f"--max_workers={BIOFORMATS_NUM_WORKERS}",
         "--scale-format-string",
         "%2$d",
         "--compression",


### PR DESCRIPTION
Addresses https://github.com/niaid/image_portal_workflows/issues/273

### Changes

* The changes were made in lrg2d workflow and utils.neuroglancer

### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [ ] tests
