### PR TITLE
Update configs for java and lrg_flow.convert

### DIFF
--- a/em_workflows/config.py
+++ b/em_workflows/config.py
@@ -16,14 +16,19 @@ load_dotenv()
 def SLURM_exec():
     """
     brings up a dynamically sized cluster.
-    For some reason processes > 1 crash BRT. Be careful optimizing this.
+
+    The job_script() for the given cluster generates:
+    python -m distributed.cli.dask_worker tcp://<some-IP> --nthreads 15 --nworkers 4 --memory-limit 96.62GiB ...
+
+    The processes determins number of dask workers, and nthreads = cores / processes
+    The memory limit is also divided among the workers
     """
     home = os.environ["HOME"]
     cluster = SLURMCluster(
         name="dask-worker",
-        cores=60,
-        memory="32G",
-        # processes=1,
+        cores=62,
+        memory="430G",
+        processes=4,
         death_timeout=121,
         local_directory=f"{home}/dask_tmp/",
         queue="gpu",

--- a/em_workflows/constants.py
+++ b/em_workflows/constants.py
@@ -1,16 +1,12 @@
-from os import cpu_count
 from collections import namedtuple
 
 LARGE_DIM = 1024
 SMALL_DIM = 300
 
-# at 20 we're seeing drop off in perf increases on HPC, tune this over time.
-if cpu_count() is None:
-    BIOFORMATS_NUM_WORKERS = 1
-elif cpu_count() - 2 > 20:
-    BIOFORMATS_NUM_WORKERS = 20
-else:
-    BIOFORMATS_NUM_WORKERS = cpu_count() - 2
+BIOFORMATS_NUM_WORKERS = 3
+# This is expected to be less than the available memory for a dask worker
+# Ref em_workflows/config:SLURM_exec
+JAVA_MAX_HEAP_SIZE = "-Xmx40G"
 
 # Refer to AssetType.yaml in documentation source for reference
 ASSET_TYPE = namedtuple(


### PR DESCRIPTION
Addresses

### Changes

* Increases Java max heap size
* Increase number of dask workers (1 -> 4) and memory (32G -> 400G)

### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [x] tests
