### PR TITLE
Increase tiling size (for czi files) in bf2raw

### DIFF
--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -84,6 +84,8 @@ def generate_czi_imageset(file_path: FilePath):
         file_path=file_path,
         input_fname=input_czi,
         rechunk=True,
+        width=4096,
+        height=4096,
     )
     imageSet = gen_imageSet(file_path=file_path)
     # extract images from input file, used to create imageSet elements


### PR DESCRIPTION
Addresses https://github.com/niaid/image_portal_workflows/issues/324

### Changes

* Increased tiling size for czi to zarr conversion using bf2raw

### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [x] tests
