### PR TITLE
removing --scale-format-string from bioformats command

### DIFF
--- a/em_workflows/utils/neuroglancer.py
+++ b/em_workflows/utils/neuroglancer.py
@@ -36,8 +36,6 @@ def bioformats_gen_zarr(
     cmd = [
         Config.bioformats2raw,
         f"--max_workers={BIOFORMATS_NUM_WORKERS}",
-        "--scale-format-string",
-        "%2$d",
         "--overwrite",
         "--compression",
         "blosc",


### PR DESCRIPTION
Addresses #330 

### Changes

* removes    `--scale-format-string "%2$d"` from bioformats2raw in utils.ng


### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [x] tests
