### PR TITLE
Fix gen_zarr mock function

### DIFF
--- a/em_workflows/utils/neuroglancer.py
+++ b/em_workflows/utils/neuroglancer.py
@@ -58,6 +58,7 @@ def bioformats_gen_zarr(
     if depth:
         cmd.extend(["--chunk_depth", str(depth)])
     else:
+        # FIXME if there's no depth we know it's a 2dmrc input
         cmd.extend(["--downsample-type", "AREA"])
 
     utils.log("Creating zarr...")


### PR DESCRIPTION
Mocking `reuse_zarr` does not handle missing .zarr files. Because it recursively calls the same mocked function.

### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [x] tests
