### PR TITLE
Fixes the removal of `scale-string-format` argument from bioformats2raw

### DIFF
--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -503,7 +503,7 @@ def gen_ng_metadata(fp_in: FilePath) -> Dict:
     file_path = fp_in
     asset_fp = Path(f"{file_path.assets_dir}/{file_path.base}.zarr")
 
-    first_zarr_arr = Path(asset_fp.as_posix() + "/0")
+    first_zarr_arr = Path(asset_fp.as_posix() + "/0/0")
 
     ng_asset = file_path.gen_asset(
         asset_type=AssetType.NEUROGLANCER_ZARR, asset_fp=asset_fp

--- a/em_workflows/sem_tomo/flow.py
+++ b/em_workflows/sem_tomo/flow.py
@@ -235,7 +235,7 @@ def gen_ng_metadata(fp_in: FilePath) -> Dict:
     file_path = fp_in
     asset_fp = Path(f"{file_path.assets_dir}/{file_path.base}.zarr")
 
-    first_zarr_arr = Path(asset_fp.as_posix() + "/0")
+    first_zarr_arr = Path(asset_fp.as_posix() + "/0/0")
 
     ng_asset = file_path.gen_asset(
         asset_type=AssetType.NEUROGLANCER_ZARR, asset_fp=asset_fp

--- a/em_workflows/utils/neuroglancer.py
+++ b/em_workflows/utils/neuroglancer.py
@@ -69,7 +69,7 @@ def bioformats_gen_zarr(
 
 
 def zarr_build_multiscales(file_path: FilePath) -> None:
-    zarr = Path(f"{file_path.assets_dir}/{file_path.base}.zarr")
+    zarr = Path(f"{file_path.assets_dir}/{file_path.base}.zarr/0")
     log_file = f"{file_path.working_dir}/{file_path.base}.log"
 
     utils.log("Building multiscales...")


### PR DESCRIPTION
The zgroups aren't flattened for `brt` and `sem` flows (which was the default behavior previously). In order to compensate that, `/0` subdirectory is added to the back of the parent directory.

Closes #332 

### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [x] tests
