### PR TITLE
Update shader parameters spec to include XYC dimensions

### DIFF
--- a/docs/source/NeuroglancerMetadata.yaml
+++ b/docs/source/NeuroglancerMetadata.yaml
@@ -11,6 +11,7 @@ properties:
     type: string
     enum:
       - XY
+      - XYC
       - XYZ
   shader:
     type: string

--- a/docs/source/metadata.yml
+++ b/docs/source/metadata.yml
@@ -42,7 +42,7 @@
 # Proposed RGB specification ( could be dimension:XYZ in the future )
 "metadata": {
     "shader" : "RGB",
-    "dimensions" : "XY",
+    "dimensions" : "XYC",
     "shaderParameters" : {}
   }
 
@@ -50,7 +50,7 @@
 # Proposed MultiChannel metadata
 "metadata": {
   "shader": "MultiChannel",
-  "dimensions": "XY",
+  "dimensions": "XYC",
   "shaderParameters": {
     "contrast": 0.0,
     "brightness": 0.0,


### PR DESCRIPTION
The dimension field is taken from the dimensions of the ZARR file which are ">1". The current supported types include what is listed in the spec. Other subsets of XYZCT are possible in the future.


### Changes

Updates the neuroglancer shader parameters to match the what is produced and describes the used dimensions of the data set.


