### PR TITLE
Change locations for zarr image in single image workflows

### DIFF
--- a/test/test_brt.py
+++ b/test/test_brt.py
@@ -5,6 +5,7 @@ test_brt.py runs an end-to-end test of the batchruntomo pipeline
 NOTE: These tests depend on setup performed in conftest.py
 """
 import pytest
+import json
 from pathlib import Path
 
 
@@ -34,3 +35,37 @@ def test_brt(mock_nfs_mount):
         keep_workdir=True,
     )
     assert result.is_successful(), "`result` is not successful!"
+
+
+@pytest.mark.localdata
+@pytest.mark.slow
+def test_brt_callback(mock_nfs_mount, mock_callback_data):
+    from em_workflows.brt.flow import flow
+
+    input_dir = "test/input_files/brt_inputs/Projects/"
+    if not Path(input_dir).exists():
+        pytest.skip("Directory doesn't exist")
+
+    result = flow.run(
+        adoc_template="plastic_brt",
+        montage=0,
+        gold=15,
+        focus=0,
+        fiducialless=1,
+        trackingMethod=None,
+        TwoSurfaces=0,
+        TargetNumberOfBeads=20,
+        LocalAlignments=0,
+        THICKNESS=30,
+        file_share="test",
+        input_dir=input_dir,
+        no_api=True,
+        keep_workdir=True,
+    )
+    assert result.is_successful(), "`result` is not successful!"
+
+    callback_output = {}
+    with open(mock_callback_data) as fd:
+        callback_output = json.load(fd)
+
+    assert "files" in callback_output

--- a/test/test_czi.py
+++ b/test/test_czi.py
@@ -101,7 +101,7 @@ def test_czi_workflow_callback_structure(
     with open(mock_callback_data) as fd:
         callback_output = json.load(fd)
 
-    # Belwo, assert possible structures and data sanitation checks
+    # Below, assert possible structures and data sanitation checks
     assert "files" in callback_output
     # .czi files and length of the callback.files is equal
     assert len(


### PR DESCRIPTION
Adds nesting for zarr file locations for single image workflows ( Closes #343 ) 
Previously, zarr directory structure was affected by `scale-format-string` argument in bf2raw command which has been removed.

Update SEM neuroglancer metadata to new format (Closes #342 )

### This PR doesn't introduce any:

- [ ] Binary files
- [ ] Temporary files, auto-generated files
- [ ] Secret keys
- [ ] Local debugging `print` statements
- [ ] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [ ] tests
