### PR TITLE
hardcode in XY for API

### DIFF
--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -66,9 +66,11 @@ def gen_imageSet(file_path: FilePath) -> List:
             ng_asset = file_path.gen_asset(
                 asset_type="neuroglancerZarr", asset_fp=Path(zarr_fp) / zarr_idx
             )
+            # note - dims should be image.dims, but GUI does not want XYC
+            # hardcoding in XY for now.
             ng_asset["metadata"] = dict(
                 shader=image.shader_type,
-                dimensions=image.dims,
+                dimensions="XY",
                 shaderParameters=image.neuroglancer_shader_parameters(),
             )
             assets.append(ng_asset)

--- a/em_workflows/lrg_2d_rgb/flow.py
+++ b/em_workflows/lrg_2d_rgb/flow.py
@@ -75,9 +75,11 @@ def generate_ng_asset(file_path: FilePath) -> Dict:
     ng_asset = file_path.gen_asset(
         asset_type=AssetType.NEUROGLANCER_ZARR, asset_fp=first_zarr_arr
     )
+    # the GUI / API does not want to see dims XYC, will set to 'XY' for now
+    # should be hw_image.dims
     ng_asset["metadata"] = dict(
         shader=hw_image.shader_type,
-        dimensions=hw_image.dims,
+        dimensions="XY",
         shaderParameters=hw_image.neuroglancer_shader_parameters(),
     )
     return ng_asset


### PR DESCRIPTION
Addresses (eg: #349)

### Changes

* Changes call from `HedwigZarrImage.dims` to hard coded 'XY' string, as API is unable to consume 'XYC'