### PR TITLE
prevents thumb gen for IF images

### DIFF
--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -61,11 +61,12 @@ def gen_imageSet(file_path: FilePath) -> List:
             image_name = f"Scene {k_idx}"
         image_elt["imageName"] = image_name
 
-        assets.append(
-            gen_thumb(image=image, file_path=file_path, image_name=image_name)
-        )
+        if image_name == "label image":
+            assets.append(
+                gen_thumb(image=image, file_path=file_path, image_name=image_name)
+            )
 
-        if image_name != "label image":
+        else:
             ng_asset = file_path.gen_asset(
                 asset_type="neuroglancerZarr", asset_fp=Path(zarr_fp) / zarr_idx
             )


### PR DESCRIPTION
Addresses #357 

### Changes

* List of changes
only create thumb for image name named "label image".

### This PR doesn't introduce any:

- [ ] Binary files
- [ ] Temporary files, auto-generated files
- [ ] Secret keys
- [ ] Local debugging `print` statements
- [ ] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [ ] tests
