### PR TITLE
Return OME metadata xml file location along with ng metadata

### DIFF
--- a/docs/source/demo_callback.json
+++ b/docs/source/demo_callback.json
@@ -6,7 +6,7 @@
       "thumbnailIndex": 0,
       "title": "Name of the file, file name minus path and extension",
       "fileMetadata": {
-        "TBD": "TBD"
+        "omeXml": "LNII/sbest/sbest-2023-0526-Rename/Spatial_example-2023-0526-Rename1/LNII/F13-TS005.zarr/OME/METADATA.ome.xml"
       },
       "imageSet": [
         {

--- a/em_workflows/file_path.py
+++ b/em_workflows/file_path.py
@@ -196,7 +196,7 @@ class FilePath:
         # setting to zero here, most input files will only have a single image elt.
         # will update val if czi
         thumbnailIndex = 0
-        fileMetadata = None
+        fileMetadata = dict()
         imageMetadata = None
         assets = []
         imageSetElement = {


### PR DESCRIPTION
Closes #358

### Changes

### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [x] tests
