### PR TITLE
Add missing copy workdir to assets for all workflows

### DIFF
--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -151,6 +151,7 @@ def czi_flow(
         file_path=fps, callback_with_zarr=callback_with_zarrs
     )
     callback_with_zarrs = find_thumb_idx(callback=callback_with_zarrs)
+    utils.copy_workdirs.map(fps, wait_for=[callback_with_zarrs])
     filtered_callback = utils.filter_results(callback_with_zarrs)
     cb = utils.send_callback_body(
         no_api=no_api,

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -240,6 +240,7 @@ def dm_flow(
         prim_fp=callback_with_thumbs, asset=keyimg_assets
     )
     # finally filter error states, and convert to JSON and send.
+    utils.copy_workdirs.map(fps, wait_for=[callback_with_keyimgs])
     filtered_callback = utils.filter_results(callback_with_keyimgs)
 
     cb = utils.send_callback_body(

--- a/em_workflows/lrg_2d_rgb/flow.py
+++ b/em_workflows/lrg_2d_rgb/flow.py
@@ -164,6 +164,7 @@ def lrg_2d_flow(
     callback_with_pyramids = utils.add_asset.map(
         prim_fp=callback_with_thumbs, asset=zarr_assets
     )
+    utils.copy_workdirs.map(fps, wait_for=[callback_with_pyramids])
     filtered_callback = utils.filter_results(callback_with_pyramids)
 
     cb = utils.send_callback_body(

--- a/em_workflows/sem_tomo/flow.py
+++ b/em_workflows/sem_tomo/flow.py
@@ -347,6 +347,15 @@ def sem_tomo_flow(
     callback_with_corr_movies = utils.add_asset.map(
         prim_fp=callback_with_corr_mrcs, asset=corrected_movie_assets
     )
+    utils.copy_workdirs.map(
+        fps,
+        wait_for=[
+            callback_with_corr_movies,
+            callback_with_corr_mrcs,
+            callback_with_pyramids,
+            callback_with_keyimgs,
+        ],
+    )
     # finally filter error states, and convert to JSON and send.
     filtered_callback = utils.filter_results(callback_with_corr_movies)
 


### PR DESCRIPTION
Temporary assets are saved in `brt` workflow. This behavior is extend to rest of the workflows as well.

### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [x] tests
