### PR TITLE
Remove dm and lrg-roi test input files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,13 +134,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# image stuff
-*tif
-*tiff
-*jpeg
-*jpg
-*mp4
-*mrc
+# test input files
+test/input_files/*
+!test/input_files/.gitattributes
 
 # tags
 tags

--- a/test/input_files/dm_inputs/Projects/Lab/PI/1-As-70-007.tif
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/1-As-70-007.tif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6b877d6eae496efbedc8b7e6daf9cd75605a2b63d35b4eac1352445cf614fab
-size 17797692

--- a/test/input_files/dm_inputs/Projects/Lab/PI/20210525_1416.dm4
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/20210525_1416.dm4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:646cb153e7059272d8213f643466072a9ebc330cdf47cd6f758f4aa85b22bbe2
-size 63495895

--- a/test/input_files/dm_inputs/Projects/Lab/PI/20210525_1416_A000_G000(H019).dm4
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/20210525_1416_A000_G000(H019).dm4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a7cf4d3cfd0ca2f6e1e5473a66eb968336650239f7c406c1f4ce4275c6a872cb
-size 94723639

--- a/test/input_files/dm_inputs/Projects/Lab/PI/20210525_1416_A000_G000.dm4
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/20210525_1416_A000_G000.dm4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:337c7d1479c9499ff0f252c788ca0924782ebe4a4fd4d3e65e42fd9bb283d3e0
-size 94723919

--- a/test/input_files/dm_inputs/Projects/Lab/PI/Con1E1-ApoA1-54mAu-1.jpg
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/Con1E1-ApoA1-54mAu-1.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f97a704b10a5d0e8b8d671b049be89da784bcd0b7538890eab271bde18e1bec6
-size 108442

--- a/test/input_files/dm_inputs/Projects/Lab/PI/Con1E1-ApoA1-54mAu-3.jpg
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/Con1E1-ApoA1-54mAu-3.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:03db2343ed7171f2aec79d8eacc720dccbf9e0982dda0c1e5a687b111c652485
-size 105050

--- a/test/input_files/dm_inputs/Projects/Lab/PI/P6_J128_selected_11(classes).png
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/P6_J128_selected_11(classes).png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:78c47b13384f3c40a732eaed8565aa454ee9b47df0e4dcbc6a685c9775cd6f45
-size 46167

--- a/test/input_files/dm_inputs/Projects/Lab/PI/P6_J130_fsc_iteration_001.png
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/P6_J130_fsc_iteration_001.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad6efec51be23f22624e4434ac307eec94e508f71aae884bf274f7ff7246a9e3
-size 30764

--- a/test/input_files/dm_inputs/Projects/Lab/PI/P6_J131_real_space_slices_iteration_008.png
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/P6_J131_real_space_slices_iteration_008.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:04d8b440e7338c986868e27a04941d6bd7a8c4044ced86baebb776e5b60bb1d2
-size 242536

--- a/test/input_files/dm_inputs/Projects/Lab/PI/PrP-Protein.007.tif
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/PrP-Protein.007.tif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:745f71e3d94947699596e9a4d97daccd0bc5d43bb8fd574dedd1ae03ceb4efad
-size 8397014

--- a/test/input_files/dm_inputs/Projects/Lab/PI/SARsCoV2_1.mrc
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/SARsCoV2_1.mrc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39ee0640e11c1959f810801f4e0f3572c43c9cab4df7f87ca40d534d3ee945f2
-size 33556224

--- a/test/input_files/dm_inputs/Projects/Lab/PI/WT-2hr_008.tif
+++ b/test/input_files/dm_inputs/Projects/Lab/PI/WT-2hr_008.tif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ece561dc176ace10bdc133183e1277c64535535f94179840b5664a460f2c3ed
-size 7707306

--- a/test/input_files/lrg_ROI_pngs/Projects/even_smaller.png
+++ b/test/input_files/lrg_ROI_pngs/Projects/even_smaller.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8475b87aab1cf996bca19c8ad2b234e779b7846ceeaf904ccedf8a2a655396c4
-size 6345583


### PR DESCRIPTION
Addresses #372 

Primarily, this is simply the first step to centralize test data. Test input like mentioned in the issue is very scattered. First step is to get rid of them from the repo itself.