### PR TITLE
Small 2D and BRT fixes

### DIFF
--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -522,10 +522,7 @@ def brt_flow(
     x_keep_workdir: bool = False,
     adoc_template: str = "plastic_brt",
 ):
-    if x_no_api:
-        utils.notify_api_running.submit(x_no_api=x_no_api)
-    else:
-        utils.notify_api_running.submit(token=token, callback_url=callback_url)
+    utils.notify_api_running(x_no_api, token, callback_url)
 
     # a single input_dir will have n tomograms
     input_dir_fp = utils.get_input_dir.submit(

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -522,8 +522,8 @@ def get_callback_result(callback_data: list) -> list:
     flow_run_name=utils.generate_flow_run_name,
     log_prints=True,
     task_runner=BRTConfig.HIGH_SLURM_EXECUTOR,
-    on_completion=[utils.notify_api_completion],
-    on_failure=[utils.notify_api_completion],
+    on_completion=[utils.notify_api_completion, utils.cleanup_workdir],
+    on_failure=[utils.notify_api_completion, utils.cleanup_workdir],
 )
 def brt_flow(
     # This block of params map are for adoc file specfication.
@@ -704,7 +704,7 @@ def brt_flow(
         allow_failure(callback_with_tilt_mov),
     )
 
-    utils.callback_with_cleanup(
+    utils.copy_with_callback(
         fps=fps,
         callback_result=callback_result,
         x_no_api=x_no_api,

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -43,7 +43,7 @@ import math
 from typing import Optional
 from pathlib import Path
 
-from prefect import task, flow, unmapped
+from prefect import task, flow, unmapped, allow_failure
 from pytools.HedwigZarrImages import HedwigZarrImages
 
 from em_workflows.utils import utils
@@ -471,7 +471,9 @@ def gen_ng_metadata(fp_in: FilePath) -> Dict:
     file_path = fp_in
     asset_fp = Path(f"{file_path.assets_dir}/{file_path.base}.zarr")
     working_fp = Path(f"{file_path.working_dir}/{file_path.base}.zarr")
+    utils.log("Instantiating HWZarrImages")
     hw_images = HedwigZarrImages(zarr_path=working_fp, read_only=False)
+    utils.log("Accessing first HWZarrImage")
     hw_image = hw_images[list(hw_images.get_series_keys())[0]]
 
     # NOTE: this could be replaced by hw_image.path
@@ -481,11 +483,19 @@ def gen_ng_metadata(fp_in: FilePath) -> Dict:
     ng_asset = file_path.gen_asset(
         asset_type=AssetType.NEUROGLANCER_ZARR, asset_fp=first_zarr_arr
     )
+    utils.log("Creating ng metadata")
+    utils.log("... getting shader type")
+    htype = hw_image.shader_type
+    utils.log("... getting dims")
+    hdims = hw_image.dims
+    utils.log("... getting shader params")
+    hparams = hw_image.neuroglancer_shader_parameters(mad_scale=5.0)
     ng_asset["metadata"] = {
-        "shader": hw_image.shader_type,
-        "dimensions": hw_image.dims,
-        "shaderParameters": hw_image.neuroglancer_shader_parameters(mad_scale=5.0),
+        "shader": htype,
+        "dimensions": hdims,
+        "shaderParameters": hparams,
     }
+    utils.log("DONE!!!")
     return ng_asset
 
 
@@ -554,60 +564,83 @@ def brt_flow(
     # stack dimensions - used in movie creation
     # alignment z dimension, this is only used for the tilt movie.
     ali_z_dims = gen_dimension_command.map(
-        file_path=fps, ali_or_rec=unmapped("ali"), wait_for=[brts]
+        file_path=fps, ali_or_rec=unmapped("ali"), wait_for=[allow_failure(brts)]
     )
 
     # START TILT MOVIE GENERATION:
-    ali_xs = gen_ali_x.map(file_path=fps, z_dim=ali_z_dims, wait_for=[brts])
-    asmbls = gen_ali_asmbl.map(file_path=fps, wait_for=[ali_xs])
-    mrc2tiffs = gen_mrc2tiff.map(file_path=fps, wait_for=[asmbls])
-    thumb_assets = gen_thumbs.map(file_path=fps, z_dim=ali_z_dims, wait_for=[mrc2tiffs])
-    keyimg_assets = gen_copy_keyimages.map(
-        file_path=fps, z_dim=ali_z_dims, wait_for=[mrc2tiffs]
+    ali_xs = gen_ali_x.map(
+        file_path=fps,
+        z_dim=ali_z_dims,
+        wait_for=[allow_failure(brts)],
+        return_state=True,
     )
-    tilt_movie_assets = gen_tilt_movie.map(file_path=fps, wait_for=[keyimg_assets])
+    asmbls = gen_ali_asmbl.map(file_path=fps, wait_for=[allow_failure(ali_xs)])
+    mrc2tiffs = gen_mrc2tiff.map(file_path=fps, wait_for=[allow_failure(asmbls)])
+    thumb_assets = gen_thumbs.map(
+        file_path=fps, z_dim=ali_z_dims, wait_for=[allow_failure(mrc2tiffs)]
+    )
+    keyimg_assets = gen_copy_keyimages.map(
+        file_path=fps, z_dim=ali_z_dims, wait_for=[allow_failure(mrc2tiffs)]
+    )
+    tilt_movie_assets = gen_tilt_movie.map(
+        file_path=fps, wait_for=[allow_failure(keyimg_assets)]
+    )
     cleanup_files.map(
         file_path=fps,
         pattern=unmapped("*_align_*.mrc"),
-        wait_for=[tilt_movie_assets, thumb_assets, keyimg_assets],
+        wait_for=[
+            allow_failure(tilt_movie_assets),
+            allow_failure(thumb_assets),
+            allow_failure(keyimg_assets),
+        ],
     )
     cleanup_files.map(
         file_path=fps,
         pattern=unmapped("*ali*.jpg"),
-        wait_for=[tilt_movie_assets, thumb_assets, keyimg_assets],
+        wait_for=[
+            allow_failure(tilt_movie_assets),
+            allow_failure(thumb_assets),
+            allow_failure(keyimg_assets),
+        ],
     )
     # END TILT MOVIE GENERATION
 
     # START RECONSTR MOVIE GENERATION:
     rec_z_dims = gen_dimension_command.map(
-        file_path=fps, ali_or_rec=unmapped("rec"), wait_for=[brts]
+        file_path=fps, ali_or_rec=unmapped("rec"), wait_for=[allow_failure(brts)]
     )
-    clip_avgs = gen_clip_avgs.map(file_path=fps, z_dim=rec_z_dims, wait_for=[asmbls])
+    clip_avgs = gen_clip_avgs.map(
+        file_path=fps, z_dim=rec_z_dims, wait_for=[allow_failure(asmbls)]
+    )
     averagedVolume_assets = consolidate_ave_mrcs.map(
-        file_path=fps, wait_for=[clip_avgs]
+        file_path=fps, wait_for=[allow_failure(clip_avgs)]
     )
     ave_jpgs = gen_ave_jpgs_from_ave_mrc.map(
-        file_path=fps, wait_for=[averagedVolume_assets]
+        file_path=fps, wait_for=[allow_failure(averagedVolume_assets)]
     )
-    recon_movie_assets = gen_recon_movie.map(file_path=fps, wait_for=[ave_jpgs])
+    recon_movie_assets = gen_recon_movie.map(
+        file_path=fps, wait_for=[allow_failure(ave_jpgs)]
+    )
     cleanup_files.map(
         file_path=fps,
         pattern=unmapped("*_mp4.*.jpg"),
-        wait_for=[recon_movie_assets, ave_jpgs],
+        wait_for=[allow_failure(recon_movie_assets), allow_failure(ave_jpgs)],
     )
     cleanup_files.map(
         file_path=fps,
         pattern=unmapped("*_ave*.mrc"),
-        wait_for=[recon_movie_assets, ave_jpgs],
+        wait_for=[allow_failure(recon_movie_assets), allow_failure(ave_jpgs)],
     )
     #    # END RECONSTR MOVIE
 
     # Binned volume assets, for volslicer.
-    bin_vol_assets = gen_ave_8_vol.map(file_path=fps, wait_for=[averagedVolume_assets])
+    bin_vol_assets = gen_ave_8_vol.map(
+        file_path=fps, wait_for=[allow_failure(averagedVolume_assets)]
+    )
     # finished volslicer inputs.
 
-    zarrs = gen_zarr.map(fp_in=fps, wait_for=[brts])
-    pyramid_assets = gen_ng_metadata.map(fp_in=fps, wait_for=[zarrs])
+    zarrs = gen_zarr.map(fp_in=fps, wait_for=[allow_failure(brts)])
+    pyramid_assets = gen_ng_metadata.map(fp_in=fps, wait_for=[allow_failure(zarrs)])
     #  archive_pyramid_cmds = ng.gen_archive_pyr.map(
     #      file_path=fps, wait_for=[pyramid_assets]
     #  )
@@ -636,7 +669,9 @@ def brt_flow(
     callback_with_tilt_mov = utils.add_asset.map(
         prim_fp=callback_with_recon_mov, asset=tilt_movie_assets
     )
-    copy_task = utils.copy_workdirs.map(fps, wait_for=[callback_with_tilt_mov])
+    copy_task = utils.copy_workdirs.map(
+        fps, wait_for=[allow_failure(callback_with_tilt_mov)]
+    )
     # This is to make sure that we wait for copy completes before cleanup
     for future in copy_task:
         future.result()

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -131,6 +131,7 @@ def gen_ali_asmbl(file_path: FilePath) -> None:
     ali_base_cmd.extend(alis)
     ali_base_cmd.append(ali_asmbl)
     FilePath.run(cmd=ali_base_cmd, log_file=f"{file_path.working_dir}/asmbl.log")
+    return file_path
 
 
 @task
@@ -383,6 +384,7 @@ def gen_ave_jpgs_from_ave_mrc(file_path: FilePath):
     log_file = f"{file_path.working_dir}/recon_mrc2tiff.log"
     cmd = [BRTConfig.mrc2tif_loc, "-j", "-C", "100,255", ave_mrc, mp4]
     FilePath.run(cmd=cmd, log_file=log_file)
+    return file_path
 
 
 @task
@@ -640,9 +642,7 @@ def brt_flow(
     ave_jpgs = gen_ave_jpgs_from_ave_mrc.map(
         file_path=fps, wait_for=[allow_failure(averagedVolume_assets)]
     )
-    recon_movie_assets = gen_recon_movie.map(
-        file_path=fps, wait_for=[allow_failure(ave_jpgs)]
-    )
+    recon_movie_assets = gen_recon_movie.map(file_path=allow_failure(ave_jpgs))
     cleanup_files.map(
         file_path=fps,
         pattern=unmapped("*_mp4.*.jpg"),

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -522,16 +522,23 @@ def brt_flow(
     x_keep_workdir: bool = False,
     adoc_template: str = "plastic_brt",
 ):
-    utils.notify_api_running(x_no_api, token, callback_url)
+    if x_no_api:
+        utils.notify_api_running.submit(x_no_api=x_no_api)
+    else:
+        utils.notify_api_running.submit(token=token, callback_url=callback_url)
 
     # a single input_dir will have n tomograms
-    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
+    input_dir_fp = utils.get_input_dir.submit(
+        share_name=file_share, input_dir=input_dir
+    )
     # input_dir_fp = utils.get_input_dir(input_dir=input_dir)
-    input_fps = utils.list_files(
+    input_fps = utils.list_files.submit(
         input_dir=input_dir_fp, exts=["MRC", "ST", "mrc", "st"], single_file=x_file_name
     )
 
-    fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
+    fps = utils.gen_fps.submit(
+        share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
+    )
     brts = utils.run_brt.map(
         file_path=fps,
         adoc_template=unmapped(adoc_template),

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -521,7 +521,7 @@ def get_callback_result(callback_data: list) -> list:
     name="BRT",
     flow_run_name=utils.generate_flow_run_name,
     log_prints=True,
-    task_runner=BRTConfig.SLURM_EXECUTOR,
+    task_runner=BRTConfig.HIGH_SLURM_EXECUTOR,
     on_completion=[utils.notify_api_completion],
     on_failure=[utils.notify_api_completion],
 )
@@ -563,6 +563,10 @@ def brt_flow(
     fps = utils.gen_fps.submit(
         share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
     )
+
+    # callback_results = await asyncio.gather(
+    #     *[subflow(file_path=fps[i: i+12]) for i in range(len(fps), step=12)]
+    # )
     brts = utils.run_brt.map(
         file_path=fps,
         adoc_template=unmapped(adoc_template),

--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -209,8 +209,8 @@ def update_file_metadata(file_path: FilePath, callback_with_zarr: Dict) -> Dict:
     flow_run_name=utils.generate_flow_run_name,
     log_prints=True,
     task_runner=CZIConfig.SLURM_EXECUTOR,
-    on_completion=[utils.notify_api_completion],
-    on_failure=[utils.notify_api_completion],
+    on_completion=[utils.notify_api_completion, utils.cleanup_workdir],
+    on_failure=[utils.notify_api_completion, utils.cleanup_workdir],
 )
 async def czi_flow(
     file_share: str,
@@ -246,7 +246,7 @@ async def czi_flow(
     )
     callback_with_zarrs = find_thumb_idx(callback=callback_with_zarrs)
 
-    utils.callback_with_cleanup(
+    utils.copy_with_callback(
         fps=fps,
         callback_result=callback_with_zarrs,
         x_no_api=x_no_api,

--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -238,9 +238,10 @@ async def czi_flow(
     fps = utils.gen_fps.submit(
         share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
     )
+    fp_results = fps.result()
     prim_fps = utils.gen_prim_fps.map(fp_in=fps)
     imageSets = await asyncio.gather(
-        *[generate_czi_imageset(file_path=fp) for fp in fps]
+        *[generate_czi_imageset(file_path=fp) for fp in fp_results]
     )
     callback_with_zarrs = utils.add_imageSet.map(prim_fp=prim_fps, imageSet=imageSets)
     callback_with_zarrs = update_file_metadata.map(

--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -221,10 +221,7 @@ async def czi_flow(
     x_no_api: bool = False,
     x_keep_workdir: bool = False,
 ):
-    if x_no_api:
-        utils.notify_api_running.submit(x_no_api=x_no_api)
-    else:
-        utils.notify_api_running.submit(token=token, callback_url=callback_url)
+    utils.notify_api_running(x_no_api, token, callback_url)
 
     input_dir_fp = utils.get_input_dir.submit(
         share_name=file_share, input_dir=input_dir

--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -221,14 +221,23 @@ async def czi_flow(
     x_no_api: bool = False,
     x_keep_workdir: bool = False,
 ):
-    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
+    if x_no_api:
+        utils.notify_api_running.submit(x_no_api=x_no_api)
+    else:
+        utils.notify_api_running.submit(token=token, callback_url=callback_url)
 
-    input_fps = utils.list_files(
+    input_dir_fp = utils.get_input_dir.submit(
+        share_name=file_share, input_dir=input_dir
+    )
+
+    input_fps = utils.list_files.submit(
         input_dir_fp,
         VALID_CZI_INPUTS,
         single_file=x_file_name,
     )
-    fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
+    fps = utils.gen_fps.submit(
+        share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
+    )
     prim_fps = utils.gen_prim_fps.map(fp_in=fps)
     imageSets = await asyncio.gather(
         *[generate_czi_imageset(file_path=fp) for fp in fps]

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -175,11 +175,6 @@ def scale_jpegs(file_path: FilePath, size: str) -> Optional[dict]:
     return asset_elt
 
 
-@flow(
-    name="SubFlow: Intermediate Convert",
-    log_prints=True,
-    task_runner=DMConfig.SLURM_EXECUTOR,
-)
 def convert_intermediate_files(fps):
     tif_fps = [
         fp
@@ -227,7 +222,10 @@ def dm_flow(
     -convert all mrcs in Projects dir to jpegs.
     -convert all tiffs/pngs/jpegs to correct size for thumbs, "sm" and "lg"
     """
-    utils.log("this is coming out of the flow")
+    if x_no_api:
+        utils.notify_api_running.submit(x_no_api=x_no_api)
+    else:
+        utils.notify_api_running.submit(token=token, callback_url=callback_url)
 
     # utils.log(input_dir)
     input_dir_fp = utils.get_input_dir.submit(

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -222,10 +222,7 @@ def dm_flow(
     -convert all mrcs in Projects dir to jpegs.
     -convert all tiffs/pngs/jpegs to correct size for thumbs, "sm" and "lg"
     """
-    if x_no_api:
-        utils.notify_api_running.submit(x_no_api=x_no_api)
-    else:
-        utils.notify_api_running.submit(token=token, callback_url=callback_url)
+    utils.notify_api_running(x_no_api, token, callback_url)
 
     # utils.log(input_dir)
     input_dir_fp = utils.get_input_dir.submit(
@@ -244,7 +241,7 @@ def dm_flow(
     # logs = utils.init_log.map(file_path=fps)
 
     # subflow calls are blocking, so lower task runs auto waits always
-    convert_intermediate_files(fps)
+    convert_intermediate_files(fps.result())
 
     # Finally generate all valid suffixed results
     keyimg_assets = scale_jpegs.map(fps, size=unmapped("l"))

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -230,19 +230,22 @@ def dm_flow(
     utils.log("this is coming out of the flow")
 
     # utils.log(input_dir)
-    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
+    input_dir_fp = utils.get_input_dir.submit(
+        share_name=file_share, input_dir=input_dir
+    )
 
-    input_fps = utils.list_files(
+    input_fps = utils.list_files.submit(
         input_dir_fp,
         VALID_2D_INPUT_EXTS,
         single_file=x_file_name,
     )
 
-    fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
+    fps = utils.gen_fps.submit(
+        share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
+    )
     # logs = utils.init_log.map(file_path=fps)
 
     # subflow calls are blocking, so lower task runs auto waits always
-    return
     convert_intermediate_files(fps)
 
     # Finally generate all valid suffixed results

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -200,8 +200,8 @@ def convert_intermediate_files(fps):
     flow_run_name=utils.generate_flow_run_name,
     log_prints=True,
     task_runner=DMConfig.SLURM_EXECUTOR,
-    on_completion=[utils.notify_api_completion],
-    on_failure=[utils.notify_api_completion],
+    on_completion=[utils.notify_api_completion, utils.cleanup_workdir],
+    on_failure=[utils.notify_api_completion, utils.cleanup_workdir],
 )
 def dm_flow(
     file_share: str,
@@ -253,7 +253,7 @@ def dm_flow(
         prim_fp=callback_with_thumbs, asset=keyimg_assets
     )
 
-    utils.callback_with_cleanup(
+    utils.copy_with_callback(
         fps=fps,
         callback_result=callback_with_keyimgs,
         x_no_api=x_no_api,

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -227,6 +227,9 @@ def dm_flow(
     -convert all mrcs in Projects dir to jpegs.
     -convert all tiffs/pngs/jpegs to correct size for thumbs, "sm" and "lg"
     """
+    utils.log("this is coming out of the flow")
+
+    # utils.log(input_dir)
     input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
 
     input_fps = utils.list_files(
@@ -234,10 +237,12 @@ def dm_flow(
         VALID_2D_INPUT_EXTS,
         single_file=x_file_name,
     )
+
     fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
     # logs = utils.init_log.map(file_path=fps)
 
     # subflow calls are blocking, so lower task runs auto waits always
+    return
     convert_intermediate_files(fps)
 
     # Finally generate all valid suffixed results

--- a/em_workflows/file_path.py
+++ b/em_workflows/file_path.py
@@ -217,6 +217,15 @@ class FilePath:
             imageSet=imageSet,
         )
 
+    @staticmethod
+    def gen_prim_fp_error_elt(prim_fp_elt: dict, error_msg: str) -> Dict:
+        return dict(
+            primaryFilePath=prim_fp_elt["primaryFilePath"],
+            title=prim_fp_elt["title"],
+            message=error_msg,
+            status="error",
+        )
+
     def copy_workdir_to_assets(self) -> Path:
         """
         - copies all of working dir to Assets dir.

--- a/em_workflows/file_path.py
+++ b/em_workflows/file_path.py
@@ -103,7 +103,7 @@ class FilePath:
         eg: /gs1/home/macmenaminpe/tmp/tmp7gcsl4on/tomogram_fname/
         Will be rm'd upon completion.
         """
-        working_dir = Path(tempfile.mkdtemp(dir=f"{Config.tmp_dir}"))
+        working_dir = tempfile.mkdtemp(dir=f"{Config.tmp_dir}")
         return Path(working_dir)
 
     def make_assets_dir(self) -> Path:

--- a/em_workflows/lrg_2d_rgb/flow.py
+++ b/em_workflows/lrg_2d_rgb/flow.py
@@ -139,8 +139,8 @@ def gen_thumb(file_path: FilePath):
     flow_run_name=utils.generate_flow_run_name,
     log_prints=True,
     task_runner=LRG2DConfig.SLURM_EXECUTOR,
-    on_completion=[utils.notify_api_completion],
-    on_failure=[utils.notify_api_completion],
+    on_completion=[utils.notify_api_completion, utils.cleanup_workdir],
+    on_failure=[utils.notify_api_completion, utils.cleanup_workdir],
 )
 # run_config=LocalRun(labels=[utils.get_environment()]),
 def lrg_2d_flow(
@@ -183,7 +183,7 @@ def lrg_2d_flow(
         prim_fp=callback_with_thumbs, asset=zarr_assets
     )
 
-    utils.callback_with_cleanup(
+    utils.copy_with_callback(
         fps=fps,
         callback_result=callback_with_pyramids,
         x_no_api=x_no_api,

--- a/em_workflows/lrg_2d_rgb/flow.py
+++ b/em_workflows/lrg_2d_rgb/flow.py
@@ -157,10 +157,7 @@ def lrg_2d_flow(
     -create tmp dir for each.
     -convert to tiff -> zarr -> jpegs (thumb)
     """
-    if x_no_api:
-        utils.notify_api_running.submit(x_no_api=x_no_api)
-    else:
-        utils.notify_api_running.submit(token=token, callback_url=callback_url)
+    utils.notify_api_running(x_no_api, token, callback_url)
 
     input_dir_fp = utils.get_input_dir.submit(
         share_name=file_share, input_dir=input_dir

--- a/em_workflows/lrg_2d_rgb/flow.py
+++ b/em_workflows/lrg_2d_rgb/flow.py
@@ -158,18 +158,22 @@ def lrg_2d_flow(
     -convert to tiff -> zarr -> jpegs (thumb)
     """
     if x_no_api:
-        utils.notify_api_running(x_no_api=x_no_api)
+        utils.notify_api_running.submit(x_no_api=x_no_api)
     else:
-        utils.notify_api_running(token=token, callback_url=callback_url)
+        utils.notify_api_running.submit(token=token, callback_url=callback_url)
 
-    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
+    input_dir_fp = utils.get_input_dir.submit(
+        share_name=file_share, input_dir=input_dir
+    )
 
-    input_fps = utils.list_files(
+    input_fps = utils.list_files.submit(
         input_dir_fp,
         VALID_LRG_2D_RGB_INPUTS,
         single_file=x_file_name,
     )
-    fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
+    fps = utils.gen_fps.submit(
+        share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
+    )
     tiffs = convert_png_to_tiff.map(file_path=fps)
     zarrs = gen_zarr.map(file_path=fps, wait_for=[tiffs])
     rechunk = rechunk_zarr.map(file_path=fps, wait_for=[zarrs])

--- a/em_workflows/sem_tomo/flow.py
+++ b/em_workflows/sem_tomo/flow.py
@@ -316,10 +316,7 @@ def sem_tomo_flow(
     x_keep_workdir: bool = False,
     tilt_angle: float = 0,
 ):
-    if x_no_api:
-        utils.notify_api_running.submit(x_no_api=x_no_api)
-    else:
-        utils.notify_api_running.submit(token=token, callback_url=callback_url)
+    utils.notify_api_running(x_no_api, token, callback_url)
 
     input_dir_fp = utils.get_input_dir.submit(
         share_name=file_share, input_dir=input_dir

--- a/em_workflows/sem_tomo/flow.py
+++ b/em_workflows/sem_tomo/flow.py
@@ -316,13 +316,20 @@ def sem_tomo_flow(
     x_keep_workdir: bool = False,
     tilt_angle: float = 0,
 ):
-    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
+    if x_no_api:
+        utils.notify_api_running.submit(x_no_api=x_no_api)
+    else:
+        utils.notify_api_running.submit(token=token, callback_url=callback_url)
+
+    input_dir_fp = utils.get_input_dir.submit(
+        share_name=file_share, input_dir=input_dir
+    )
     # note FIBSEM is different to other flows in that it uses *directories*
     # to define stacks. Therefore, will have to list dirs to discover stacks
     # (rather than eg mrc files)
-    input_dir_fps = utils.list_dirs(input_dir_fp=input_dir_fp)
+    input_dir_fps = utils.list_dirs.submit(input_dir_fp=input_dir_fp)
 
-    fps = utils.gen_fps(
+    fps = utils.gen_fps.submit(
         share_name=file_share, input_dir=input_dir_fp, fps_in=input_dir_fps
     )
     tif_to_mrc = convert_tif_to_mrc.map(fps)

--- a/em_workflows/sem_tomo/flow.py
+++ b/em_workflows/sem_tomo/flow.py
@@ -303,8 +303,8 @@ def gen_ng_metadata(fp_in: FilePath) -> Dict:
     flow_run_name=utils.generate_flow_run_name,
     log_prints=True,
     task_runner=SEMConfig.SLURM_EXECUTOR,
-    on_completion=[utils.notify_api_completion],
-    on_failure=[utils.notify_api_completion],
+    on_completion=[utils.notify_api_completion, utils.cleanup_workdir],
+    on_failure=[utils.notify_api_completion, utils.cleanup_workdir],
 )
 def sem_tomo_flow(
     file_share: str,
@@ -377,7 +377,7 @@ def sem_tomo_flow(
         prim_fp=callback_with_corr_mrcs, asset=corrected_movie_assets
     )
 
-    utils.callback_with_cleanup(
+    utils.copy_with_callback(
         fps=fps,
         callback_result=callback_with_corr_movies,
         x_no_api=x_no_api,

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -347,6 +347,7 @@ def run_brt(
     for _file in [rec_file, ali_file]:
         if not _file.exists():
             raise RuntimeError(f"File {_file} does not exist. BRT run failure.")
+    return file_path
     # brts_ok = check_brt_run_ok(file_path=file_path)
 
 

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -184,13 +184,16 @@ def cleanup_workdir(flow: Flow, flow_run: FlowRun, state: State):
         return
 
     tmpdirs_path = get_flow_run_tmpdirs(flow_run.flow_id)
+    hooks_log = open(f"slurm-log/{flow_run.flow_id}-hooks-log.txt", "w")
     with open(tmpdirs_path) as f:
         lines = f.readlines()
         for tmpdir in lines:
             # make sure that we are deleting something temporary
             assert "tmp" in tmpdir
             shutil.rmtree(tmpdir.strip(), ignore_errors=True)
-            log(f"Removed {tmpdir}")
+            hooks_log.write(f"Removed working dir: {tmpdir}")
+    tmpdirs_path.unlink()
+    hooks_log.close()
 
 
 def update_adoc(
@@ -542,7 +545,7 @@ def notify_api_completion(flow: Flow, flow_run: FlowRun, state: State):
 
     # Logs from state chaange hooks do not reflect in prefect logs
     # therefore, we have to setup such logs manually
-    hooks_log = open(f"slurm-log/{flowrun_id}-notify-api-completion.txt", "w")
+    hooks_log = open(f"slurm-log/{flowrun_id}-hooks-log.txt", "w")
     hooks_log.write(f"Trying to notify: {x_no_api=}, {token=}, {callback_url=}\n")
 
     headers = {

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -535,6 +535,8 @@ def notify_api_completion(flow: Flow, flow_run: FlowRun, state: State):
         log(f"x_no_api flag used\nCompletion status: {status}")
         return
 
+    # Logs from state chaange hooks do not reflect in prefect logs
+    # therefore, we have to setup such logs manually
     hooks_log = open(f"slurm-log/{flowrun_id}-notify-api-completion.txt", "w")
     hooks_log.write(f"Trying to notify: {x_no_api=}, {token=}, {callback_url=}\n")
 

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -522,10 +522,8 @@ def notify_api_completion(flow: Flow, flow_run: FlowRun, state: State):
     https://docs.prefect.io/core/concepts/states.html#overview.
     https://docs.prefect.io/core/concepts/notifications.html#state-handlers
     """
-    x_no_api = flow_run.parameters.get("x_no_api", "not-found")
-    # implicit
-    raise RuntimeError(f"Checking... {x_no_api}")
-    status = "success" if state.is_completed else "error"
+    status = "success" if state.is_completed() else "error"
+    x_no_api = flow_run.parameters.get("x_no_api", False)
     token = flow_run.parameters.get("token", "")
     callback_url = flow_run.parameters.get("callback_url", "")
 

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -531,12 +531,11 @@ def notify_api_completion(flow: Flow, flow_run: FlowRun, state: State):
 
     flowrun_id = os.environ.get("PREFECT__FLOW_RUN_ID", "not-found")
 
-    hooks_log = open(f"slurm-log/{flowrun_id}-notify-api-completion.txt", "w")
     if x_no_api:
         log(f"x_no_api flag used\nCompletion status: {status}")
-        hooks_log.close()
         return
 
+    hooks_log = open(f"slurm-log/{flowrun_id}-notify-api-completion.txt", "w")
     hooks_log.write(f"Trying to notify: {x_no_api=}, {token=}, {callback_url=}\n")
 
     headers = {

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -576,12 +576,17 @@ def get_input_dir(share_name: str, input_dir: str) -> Path:
     | create working dir
     | returns Path obj
     """
+    log("this is really dumb - in input_dir")
     if not input_dir.endswith("/"):
         input_dir = input_dir + "/"
     if not input_dir.startswith("/"):
         input_dir = "/" + input_dir
     input_path_str = Config.proj_dir(share_name=share_name) + input_dir
-    return Path(input_path_str)
+    p = Path(input_path_str)
+    log(f"Checking input dir {p.as_posix()} which exists? {p.exists()}")
+    if not p.exists():
+        raise RuntimeError(f"Fail get_input_dir, {p.as_posix()} does not exist")
+    return p
 
 
 @task
@@ -591,7 +596,9 @@ def gen_fps(share_name: str, input_dir: Path, fps_in: List[Path]) -> List[FilePa
     a list of FilePaths for the input files. This includes a temporary working
     directory for each file to keep the files separate on the HPC.
     """
+    log("Creating FPS...")
     fps = list()
+    return fps
     for fp in fps_in:
         file_path = FilePath(share_name=share_name, input_dir=input_dir, fp_in=fp)
         msg = f"created working_dir {file_path.working_dir} for {fp.as_posix()}"

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -522,8 +522,10 @@ def notify_api_completion(flow: Flow, flow_run: FlowRun, state: State):
     https://docs.prefect.io/core/concepts/states.html#overview.
     https://docs.prefect.io/core/concepts/notifications.html#state-handlers
     """
-    status = "Completed" if state.is_completed else "Failed"
-    x_no_api = flow_run.parameters.get("x_no_api", True)
+    x_no_api = flow_run.parameters.get("x_no_api", "not-found")
+    # implicit
+    raise RuntimeError(f"Checking... {x_no_api}")
+    status = "success" if state.is_completed else "error"
     token = flow_run.parameters.get("token", "")
     callback_url = flow_run.parameters.get("callback_url", "")
 
@@ -539,11 +541,15 @@ def notify_api_completion(flow: Flow, flow_run: FlowRun, state: State):
         callback_url, headers=headers, data=json.dumps({"status": status})
     )
     log(f"Pipeline status is:{status}")
+    print(f"Pipeline status is:{status}")
     log(response.text)
+    print(response.text)
     log(response.headers)
+    print(response.headers)
     if not response.ok:
         msg = f"Bad response code on callback: {response}"
         log(msg=msg)
+        print(msg=msg)
         raise RuntimeError(msg)
     return response.ok
 

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -596,9 +596,7 @@ def gen_fps(share_name: str, input_dir: Path, fps_in: List[Path]) -> List[FilePa
     a list of FilePaths for the input files. This includes a temporary working
     directory for each file to keep the files separate on the HPC.
     """
-    log("Creating FPS...")
     fps = list()
-    return fps
     for fp in fps_in:
         file_path = FilePath(share_name=share_name, input_dir=input_dir, fp_in=fp)
         msg = f"created working_dir {file_path.working_dir} for {fp.as_posix()}"
@@ -660,16 +658,16 @@ def callback_with_cleanup(
 ):
     cp_wd_logs_to_assets = copy_workdir_logs.map(fps, wait_for=[callback_result])
 
-    cb = send_callback_body(
+    cb = send_callback_body.submit(
         x_no_api=x_no_api,
         token=token,
         callback_url=callback_url,
         files_elts=callback_result,
     )
-    cleanup_workdir(
+    cleanup_workdir.submit(
         fps,
         x_keep_workdir,
-        wait_for=[allow_failure(cb), allow_failure(cp_wd_logs_to_assets)],
+        wait_for=[cb, allow_failure(cp_wd_logs_to_assets)],
     )
 
 

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -8,11 +8,11 @@ from typing import List, Dict
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
+import prefect
 from prefect import task, get_run_logger, allow_failure
 from prefect.exceptions import MissingContextError
 from prefect.states import State
 from prefect.flows import Flow, FlowRun
-from prefect.runtime import flow_run
 
 from em_workflows.config import Config
 from em_workflows.file_path import FilePath
@@ -171,22 +171,26 @@ def add_asset(prim_fp: dict, asset: dict, image_idx: int = None) -> dict:
     return prim_fp
 
 
-# triggers like "always_run" are managed when calling the task itself
-@task(retries=3, retry_delay_seconds=10)
-def cleanup_workdir(fps: List[FilePath], x_keep_workdir: bool):
+def cleanup_workdir(flow: Flow, flow_run: FlowRun, state: State):
     """
     :param fp: a FilePath which has a working_dir to be removed
 
     | working_dir isn't needed after run, so remove unless "x_keep_workdir" is True.
-    | task wrapper on the FilePath rm_workdir method.
-
+    | Reads tmpdirs.log for given flow run and deletes mentioned folders
     """
+    x_keep_workdir = flow_run.parameters.get("x_keep_workdir", False)
     if x_keep_workdir is True:
         log("x_keep_workdir is set to True, skipping removal.")
-    else:
-        for fp in fps:
-            log(f"Trying to remove {fp.working_dir}")
-            fp.rm_workdir()
+        return
+
+    tmpdirs_path = get_flow_run_tmpdirs(flow_run.flow_id)
+    with open(tmpdirs_path) as f:
+        lines = f.readlines()
+        for tmpdir in lines:
+            # make sure that we are deleting something temporary
+            assert "tmp" in tmpdir
+            shutil.rmtree(tmpdir.strip(), ignore_errors=True)
+            log(f"Removed {tmpdir}")
 
 
 def update_adoc(
@@ -605,6 +609,10 @@ def get_input_dir(share_name: str, input_dir: str) -> Path:
     return p
 
 
+def get_flow_run_tmpdirs(flow_run_id):
+    return Path.home() / "slurm-log" / (str(flow_run_id) + "-tmpdirs.log")
+
+
 @task
 def gen_fps(share_name: str, input_dir: Path, fps_in: List[Path]) -> List[FilePath]:
     """
@@ -613,11 +621,16 @@ def gen_fps(share_name: str, input_dir: Path, fps_in: List[Path]) -> List[FilePa
     directory for each file to keep the files separate on the HPC.
     """
     fps = list()
+    flow_context = prefect.context.FlowRunContext.get()
+    tmpdirs_path = get_flow_run_tmpdirs(flow_context.flow_run.flow_id)
+    tmpdirs = open(tmpdirs_path, "w")
     for fp in fps_in:
         file_path = FilePath(share_name=share_name, input_dir=input_dir, fp_in=fp)
         msg = f"created working_dir {file_path.working_dir} for {fp.as_posix()}"
         log(msg)
         fps.append(file_path)
+        tmpdirs.write(f"{file_path.working_dir}")
+    tmpdirs.close()
     return fps
 
 
@@ -664,7 +677,7 @@ def send_callback_body(
         )
 
 
-def callback_with_cleanup(
+def copy_with_callback(
     fps: List[FilePath],
     callback_result: List,
     x_no_api: bool = False,
@@ -674,21 +687,10 @@ def callback_with_cleanup(
 ):
     cp_wd_logs_to_assets = copy_workdir_logs.map(fps, wait_for=[callback_result])
 
-    cb = send_callback_body.submit(
+    send_callback_body.submit(
         x_no_api=x_no_api,
         token=token,
         callback_url=callback_url,
         files_elts=callback_result,
+        wait_for=[allow_failure(cp_wd_logs_to_assets)],
     )
-    cleanup_workdir.submit(
-        fps,
-        x_keep_workdir,
-        wait_for=[cb, allow_failure(cp_wd_logs_to_assets)],
-    )
-
-
-def generate_flow_run_name():
-    parameters = flow_run.parameters
-    name = Path(parameters["input_dir"])
-    share_name = parameters["file_share"]
-    return f"{share_name} | {name.parts[-2]} / {name.parts[-1]}"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,6 +21,7 @@ def mock_binaries(monkeypatch):
 
     monkeypatch.setattr(Config, "tmp_dir", "/tmp")
     monkeypatch.setattr(Config, "SLURM_EXECUTOR", ConcurrentTaskRunner())
+    monkeypatch.setattr(Config, "HIGH_SLURM_EXECUTOR", ConcurrentTaskRunner())
 
 
 @pytest.fixture

--- a/test/test_brt.py
+++ b/test/test_brt.py
@@ -4,8 +4,9 @@ test_brt.py runs an end-to-end test of the batchruntomo pipeline
 
 NOTE: These tests depend on setup performed in conftest.py
 """
-import pytest
+import os
 import json
+import pytest
 from pathlib import Path
 
 
@@ -49,9 +50,18 @@ def test_brt_callback_one_valid_of_two_inputs(
     """
     from em_workflows.brt.flow import brt_flow
 
-    input_dir = "test/input_files/brt/Projects/RT_TOMO/"
+    input_dir = Path("test") / "input_files" / "brt" / "Projects" / "RT_TOMO" / "Part"
     if not Path(input_dir).exists():
         pytest.skip(f"Directory {input_dir} doesn't exist")
+
+    valid_mrc, broken_st = (
+        "2013-1220-dA30_5-BSC-1_10.mrc",
+        "broken-20130412-Vn-poxtomo_8.st",
+    )
+    assert os.listdir(input_dir) == [
+        valid_mrc,
+        broken_st,
+    ], "One valid and a broken file should have existed."
 
     result = brt_flow(
         adoc_template="plastic_brt",
@@ -65,7 +75,7 @@ def test_brt_callback_one_valid_of_two_inputs(
         LocalAlignments=0,
         THICKNESS=30,
         file_share="test",
-        input_dir=input_dir,
+        input_dir=input_dir.as_posix(),
         x_no_api=True,
         x_keep_workdir=True,
         return_state=True,
@@ -77,5 +87,5 @@ def test_brt_callback_one_valid_of_two_inputs(
         callback_output = json.load(fd)
 
     assert "files" in callback_output
-    print(callback_output["files"])
-    assert False
+    assert len(callback_output["files"]) == 1, "Only one file should have passed"
+    assert valid_mrc in callback_output["files"][0]["primaryFilePath"]

--- a/test/test_brt.py
+++ b/test/test_brt.py
@@ -77,4 +77,5 @@ def test_brt_callback_one_valid_of_two_inputs(
         callback_output = json.load(fd)
 
     assert "files" in callback_output
-    assert False, "Failing... "
+    print(callback_output["files"])
+    assert False

--- a/test/test_brt.py
+++ b/test/test_brt.py
@@ -40,7 +40,13 @@ def test_brt(mock_nfs_mount):
 
 @pytest.mark.localdata
 @pytest.mark.slow
-def test_brt_callback(mock_nfs_mount, caplog, mock_callback_data):
+def test_brt_callback_one_valid_of_two_inputs(
+    mock_nfs_mount, caplog, mock_callback_data
+):
+    """
+    If one of the brt inputs is failing (out of two),
+    the callback should still send the response with one valid dictionary
+    """
     from em_workflows.brt.flow import brt_flow
 
     input_dir = "test/input_files/brt/Projects/RT_TOMO/"
@@ -71,3 +77,4 @@ def test_brt_callback(mock_nfs_mount, caplog, mock_callback_data):
         callback_output = json.load(fd)
 
     assert "files" in callback_output
+    assert False, "Failing... "


### PR DESCRIPTION
### Changes

* Add `notify api running` calls as soon as the flow runs start
* czi flow run uses async/await. Wait for prefect future results before sending it to async calls
* Remove subflow for small dm conversion flow
* Revert `Completion/Failed` to original `success/error` api calls on notify-api-completion
* Fix BRT flow: Add dependencies between task runs (replaces wait_for upstream tasks)... Increase cluster size for BRT workflow to be able to handle large number of inputs.
* `cleanup workdir` moved to hooks from tasks.
* Add error for task as messages in callback response using task failure hooks (uses file i/o)

### Shortcomings

* Using file i/o to store errors (this is used to collect error messages to collate in callback response; also, [here](https://github.com/niaid/image_portal_workflows/pull/409/files#diff-05dc3904a3c060a5d6f915296730afb1a35e8eb90b407b5124c425c48c22d8a5R87) to store which temporary file locations need to be cleared by on_completion/on_failure hooks) --- Two functions of interest in `utils.py` are: `get_flow_run_tmpdirs` and `store_exception_hook` (for two respective issues).

### This PR doesn't introduce any:

- [x] Binary files
- [x] Temporary files, auto-generated files
- [x] Secret keys
- [x] Local debugging `print` statements
- [x] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [ ] tests
