### PR TITLE
Small 2D fix and refactor BRT

### DIFF
--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -522,10 +522,7 @@ def brt_flow(
     x_keep_workdir: bool = False,
     adoc_template: str = "plastic_brt",
 ):
-    if x_no_api:
-        utils.notify_api_running.submit(x_no_api=x_no_api)
-    else:
-        utils.notify_api_running.submit(token=token, callback_url=callback_url)
+    utils.notify_api_running(x_no_api, token, callback_url)
 
     # a single input_dir will have n tomograms
     input_dir_fp = utils.get_input_dir.submit(

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -569,24 +569,39 @@ def brt_flow(
 
     # START TILT MOVIE GENERATION:
     ali_xs = gen_ali_x.map(
-        file_path=fps, z_dim=ali_z_dims, wait_for=[allow_failure(brts)]
+        file_path=fps,
+        z_dim=ali_z_dims,
+        wait_for=[allow_failure(brts)],
+        return_state=True,
     )
-    asmbls = gen_ali_asmbl.map(file_path=fps, wait_for=[ali_xs])
-    mrc2tiffs = gen_mrc2tiff.map(file_path=fps, wait_for=[asmbls])
-    thumb_assets = gen_thumbs.map(file_path=fps, z_dim=ali_z_dims, wait_for=[mrc2tiffs])
+    asmbls = gen_ali_asmbl.map(file_path=fps, wait_for=[allow_failure(ali_xs)])
+    mrc2tiffs = gen_mrc2tiff.map(file_path=fps, wait_for=[allow_failure(asmbls)])
+    thumb_assets = gen_thumbs.map(
+        file_path=fps, z_dim=ali_z_dims, wait_for=[allow_failure(mrc2tiffs)]
+    )
     keyimg_assets = gen_copy_keyimages.map(
-        file_path=fps, z_dim=ali_z_dims, wait_for=[mrc2tiffs]
+        file_path=fps, z_dim=ali_z_dims, wait_for=[allow_failure(mrc2tiffs)]
     )
-    tilt_movie_assets = gen_tilt_movie.map(file_path=fps, wait_for=[keyimg_assets])
+    tilt_movie_assets = gen_tilt_movie.map(
+        file_path=fps, wait_for=[allow_failure(keyimg_assets)]
+    )
     cleanup_files.map(
         file_path=fps,
         pattern=unmapped("*_align_*.mrc"),
-        wait_for=[tilt_movie_assets, thumb_assets, keyimg_assets],
+        wait_for=[
+            allow_failure(tilt_movie_assets),
+            allow_failure(thumb_assets),
+            allow_failure(keyimg_assets),
+        ],
     )
     cleanup_files.map(
         file_path=fps,
         pattern=unmapped("*ali*.jpg"),
-        wait_for=[tilt_movie_assets, thumb_assets, keyimg_assets],
+        wait_for=[
+            allow_failure(tilt_movie_assets),
+            allow_failure(thumb_assets),
+            allow_failure(keyimg_assets),
+        ],
     )
     # END TILT MOVIE GENERATION
 
@@ -594,32 +609,38 @@ def brt_flow(
     rec_z_dims = gen_dimension_command.map(
         file_path=fps, ali_or_rec=unmapped("rec"), wait_for=[allow_failure(brts)]
     )
-    clip_avgs = gen_clip_avgs.map(file_path=fps, z_dim=rec_z_dims, wait_for=[asmbls])
+    clip_avgs = gen_clip_avgs.map(
+        file_path=fps, z_dim=rec_z_dims, wait_for=[allow_failure(asmbls)]
+    )
     averagedVolume_assets = consolidate_ave_mrcs.map(
-        file_path=fps, wait_for=[clip_avgs]
+        file_path=fps, wait_for=[allow_failure(clip_avgs)]
     )
     ave_jpgs = gen_ave_jpgs_from_ave_mrc.map(
-        file_path=fps, wait_for=[averagedVolume_assets]
+        file_path=fps, wait_for=[allow_failure(averagedVolume_assets)]
     )
-    recon_movie_assets = gen_recon_movie.map(file_path=fps, wait_for=[ave_jpgs])
+    recon_movie_assets = gen_recon_movie.map(
+        file_path=fps, wait_for=[allow_failure(ave_jpgs)]
+    )
     cleanup_files.map(
         file_path=fps,
         pattern=unmapped("*_mp4.*.jpg"),
-        wait_for=[recon_movie_assets, ave_jpgs],
+        wait_for=[allow_failure(recon_movie_assets), allow_failure(ave_jpgs)],
     )
     cleanup_files.map(
         file_path=fps,
         pattern=unmapped("*_ave*.mrc"),
-        wait_for=[recon_movie_assets, ave_jpgs],
+        wait_for=[allow_failure(recon_movie_assets), allow_failure(ave_jpgs)],
     )
     #    # END RECONSTR MOVIE
 
     # Binned volume assets, for volslicer.
-    bin_vol_assets = gen_ave_8_vol.map(file_path=fps, wait_for=[averagedVolume_assets])
+    bin_vol_assets = gen_ave_8_vol.map(
+        file_path=fps, wait_for=[allow_failure(averagedVolume_assets)]
+    )
     # finished volslicer inputs.
 
     zarrs = gen_zarr.map(fp_in=fps, wait_for=[allow_failure(brts)])
-    pyramid_assets = gen_ng_metadata.map(fp_in=fps, wait_for=[zarrs])
+    pyramid_assets = gen_ng_metadata.map(fp_in=fps, wait_for=[allow_failure(zarrs)])
     #  archive_pyramid_cmds = ng.gen_archive_pyr.map(
     #      file_path=fps, wait_for=[pyramid_assets]
     #  )
@@ -648,7 +669,9 @@ def brt_flow(
     callback_with_tilt_mov = utils.add_asset.map(
         prim_fp=callback_with_recon_mov, asset=tilt_movie_assets
     )
-    copy_task = utils.copy_workdirs.map(fps, wait_for=[callback_with_tilt_mov])
+    copy_task = utils.copy_workdirs.map(
+        fps, wait_for=[allow_failure(callback_with_tilt_mov)]
+    )
     # This is to make sure that we wait for copy completes before cleanup
     for future in copy_task:
         future.result()

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -36,14 +36,15 @@ Batchruntomo pipeline overview:
 """
 
 from typing import Dict
+import json
 import glob
 import os
 import subprocess
 import math
 from typing import Optional
 from pathlib import Path
-
-from prefect import task, flow, unmapped, allow_failure
+from natsort import os_sorted
+from prefect import task, flow, unmapped
 from prefect.states import Completed, Failed
 from pytools.HedwigZarrImages import HedwigZarrImages
 
@@ -55,8 +56,7 @@ from em_workflows.brt.config import BRTConfig
 from em_workflows.brt.constants import BRT_DEPTH, BRT_HEIGHT, BRT_WIDTH
 
 
-@task
-def gen_dimension_command(file_path: FilePath, ali_or_rec: str) -> str:
+def gen_dimension_command(fp_in: Path) -> str:
     """
     | looks up the z dimension of an mrc file.
     | ali_or_rec is nasty, str to denote whether you're using the `_ali` file or the `_rec` file.
@@ -64,20 +64,12 @@ def gen_dimension_command(file_path: FilePath, ali_or_rec: str) -> str:
     :todo: this is duplicate, see utils.lookup_dims()
     """
 
-    if ali_or_rec not in ["ali", "rec"]:
-        raise RuntimeError(
-            f"gen_dimension_command must be called with ali or rec, not {ali_or_rec}"
-        )
-    mrc_file = f"{file_path.working_dir}/{file_path.base}_{ali_or_rec}.mrc"
-    ali_file_p = Path(mrc_file)
-    if ali_file_p.exists():
-        utils.log(f"{mrc_file} exists")
+    if fp_in.exists():
+        utils.log(f"{fp_in} exists")
     else:
-        utils.log(f"{mrc_file} DOES NOT exist")
-        raise RuntimeError(
-            f"File {mrc_file} does not exist. gen_dimension_command failure."
-        )
-    cmd = [BRTConfig.header_loc, "-s", mrc_file]
+        utils.log(f"{fp_in} DOES NOT exist, nothing to do here.")
+        return "error"
+    cmd = [BRTConfig.header_loc, "-s", fp_in]
     sp = subprocess.run(cmd, check=False, capture_output=True)
     if sp.returncode != 0:
         stdout = sp.stdout.decode("utf-8")
@@ -96,8 +88,7 @@ def gen_dimension_command(file_path: FilePath, ali_or_rec: str) -> str:
         return str(z_dim)
 
 
-@task
-def gen_ali_x(file_path: FilePath, z_dim) -> None:
+def gen_ali_x(fp_in: Path, z_dim) -> None:
     """
     - chops an mrc input into its constituent Z sections.
     - eg if an mrc input has a z_dim of 10, 10 sections will be generated.
@@ -106,63 +97,58 @@ def gen_ali_x(file_path: FilePath, z_dim) -> None:
 
         newstack -secs {i}-{i} path/BASENAME_ali*.mrc WORKDIR/hedwig/BASENAME_ali{i}.mrc
     """
-    ali_file = f"{file_path.working_dir}/{file_path.base}_ali.mrc"
     for i in range(1, int(z_dim)):
         i_padded = str(i).rjust(3, "0")
-        ali_x = f"{file_path.working_dir}/{file_path.base}_align_{i_padded}.mrc"
-        log_file = f"{file_path.working_dir}/newstack_mid_pt.log"
-        cmd = [BRTConfig.newstack_loc, "-secs", f"{i}-{i}", ali_file, ali_x]
+        ali_x = f"{fp_in.parent}/{fp_in.stem}_align_{i_padded}.mrc"
+        log_file = f"{fp_in.parent}/newstack_mid_pt.log"
+        cmd = [BRTConfig.newstack_loc, "-secs", f"{i}-{i}", fp_in.as_posix(), ali_x]
         FilePath.run(cmd=cmd, log_file=log_file)
 
 
-@task
-def gen_ali_asmbl(file_path: FilePath) -> None:
+def gen_ali_asmbl(fp_in: Path) -> None:
     """
     Use IMOD ``newstack`` to assemble, eg::
 
        newstack -float 3 {BASENAME}_ali*.mrc ali_{BASENAME}.mrc
     """
-    alis = glob.glob(f"{file_path.working_dir}/{file_path.base}_align_*.mrc")
+    alis = glob.glob(f"{fp_in.parent}/{fp_in.stem}_align_*.mrc")
     alis.sort()
-    ali_asmbl = f"{file_path.working_dir}/ali_{file_path.base}.mrc"
+    ali_asmbl = f"{fp_in.parent}/ali_{fp_in.stem}.mrc"
     ali_base_cmd = [BRTConfig.newstack_loc, "-float", "3"]
     ali_base_cmd.extend(alis)
     ali_base_cmd.append(ali_asmbl)
-    FilePath.run(cmd=ali_base_cmd, log_file=f"{file_path.working_dir}/asmbl.log")
+    FilePath.run(cmd=ali_base_cmd, log_file=f"{fp_in.parent}/asmbl.log")
 
 
-@task
-def gen_mrc2tiff(file_path: FilePath) -> None:
+def gen_mrc2tiff(fp_in: Path) -> None:
     """
     This generates a lot of jpegs (-j) which will be compiled into a movie.
     (That is, the -jpeg switch is set to produce jpegs) eg::
 
         mrc2tif -j -C 0,255 ali_BASENAME.mrc BASENAME_ali
     """
-    ali_asmbl = f"{file_path.working_dir}/ali_{file_path.base}.mrc"
-    ali = f"{file_path.working_dir}/{file_path.base}_ali"
+    ali_asmbl = f"{fp_in.parent}/ali_{fp_in.stem}.mrc"
+    ali = f"{fp_in.parent}/{fp_in.stem}_ali"
     cmd = [BRTConfig.mrc2tif_loc, "-j", "-C", "0,255", ali_asmbl, ali]
-    log_file = f"{file_path.working_dir}/mrc2tif_align.log"
+    log_file = f"{fp_in.parent}/mrc2tif_align.log"
     FilePath.run(cmd=cmd, log_file=log_file)
 
 
 @task
-def gen_thumbs(file_path: FilePath, z_dim) -> dict:
+def gen_thumbs(middle_i_jpg: Path) -> Path:
     """
     Use GraphicsMagick to create thumbnail images, eg::
 
         gm convert -size 300x300 BASENAME_ali.{MIDDLE_I}.jpg -resize 300x300 \
                 -sharpen 2 -quality 70 keyimg_BASENAME_s.jpg
     """
-    middle_i = calc_middle_i(z_dim=z_dim)
-    middle_i_jpg = f"{file_path.working_dir}/{file_path.base}_ali.{middle_i}.jpg"
-    thumb = f"{file_path.working_dir}/keyimg_{file_path.base}_s.jpg"
+    thumb = f"{middle_i_jpg.parent}/keyimg_{middle_i_jpg.stem}_s.jpg"
     cmd = [
         "gm",
         "convert",
         "-size",
         "300x300",
-        middle_i_jpg,
+        middle_i_jpg.as_posix(),
         "-resize",
         "300x300",
         "-sharpen",
@@ -171,13 +157,9 @@ def gen_thumbs(file_path: FilePath, z_dim) -> dict:
         "70",
         thumb,
     ]
-    log_file = f"{file_path.working_dir}/thumb.log"
+    log_file = f"{middle_i_jpg.parent}/thumb.log"
     FilePath.run(cmd=cmd, log_file=log_file)
-    asset_fp = file_path.copy_to_assets_dir(fp_to_cp=Path(thumb))
-    keyimg_asset = file_path.gen_asset(
-        asset_type=AssetType.THUMBNAIL, asset_fp=asset_fp
-    )
-    return keyimg_asset
+    return Path(thumb)
 
 
 @task
@@ -209,6 +191,64 @@ def calc_middle_i(z_dim: str) -> str:
     fl_padded = str(fl).rjust(3, "0")
     utils.log(f"middle i: {fl_padded}")
     return fl_padded
+
+
+@task
+def find_middle_image(fp_in: Path) -> Path:
+    images = glob.glob(f"{fp_in.parent}/*ali*jpg")
+    images_nat_sorted = os_sorted(images)
+    middle_image = images_nat_sorted[int(len(images_nat_sorted) / 2)]
+    utils.log(f"Found middle image {middle_image}")
+    fp_out = Path(middle_image)
+    cleanup_files(file_path=fp_in, pattern="*ali*jpg", keep_file=fp_out)
+    return fp_out
+
+
+@task
+def gen_tilt_movie_2(brt_output: utils.BrtOutput) -> Path:
+    """
+    generates the tilt movie, eg::
+
+        ffmpeg -f image2 -framerate 4 -i ${BASENAME}_ali.%03d.jpg -vcodec libx264 \
+                -pix_fmt yuv420p -s 1024,1024 tiltMov_${BASENAME}.mp4
+    """
+    ali_file = brt_output.ali_file
+    utils.log(f"created alinment file {ali_file}")
+    utils.log("gen dims")
+    z_dim = gen_dimension_command(fp_in=ali_file)
+
+    utils.log("align x")
+    gen_ali_x(fp_in=ali_file, z_dim=z_dim)
+
+    utils.log("assemble x")
+    gen_ali_asmbl(fp_in=ali_file)
+
+    utils.log("mrc2tif")
+    gen_mrc2tiff(fp_in=ali_file)
+
+    input_fp = f"{ali_file.parent}/{ali_file.stem}_ali.%03d.jpg"
+    log_file = f"{ali_file.parent}/ffmpeg_tilt.log"
+    movie_file = f"{ali_file.parent}/tiltMov_{ali_file.stem}.mp4"
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-f",
+        "image2",
+        "-framerate",
+        "4",
+        "-i",
+        input_fp,
+        "-vcodec",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-s",
+        "1024,1024",
+        movie_file,
+    ]
+    FilePath.run(cmd=cmd, log_file=log_file)
+    cleanup_files(file_path=ali_file, pattern=("*_align_*.mrc"))
+    return Path(movie_file)
 
 
 @task
@@ -289,7 +329,67 @@ def gen_recon_movie(file_path: FilePath) -> dict:
 
 
 @task
-def gen_clip_avgs(file_path: FilePath, z_dim: str) -> None:
+def gen_ave_mrc(brt_output: utils.BrtOutput) -> Path:
+    rec_file = brt_output.rec_file
+    utils.log("gen recon dims")
+    rec_z_dim = gen_dimension_command(fp_in=rec_file)
+    utils.log("gen recon clip averages")
+    gen_clip_avgs(in_fp=rec_file, z_dim=rec_z_dim)
+    utils.log("gen average mrc")
+    ave_mrc = consolidate_ave_mrcs(fp_in=rec_file)
+    utils.log(f"average mrc: {ave_mrc}")
+    return ave_mrc
+
+
+@task
+def gen_recon_movie_2(ave_mrc: Path) -> Path:
+    """
+    compiles a stack of jpgs into a movie. eg::
+
+        ffmpeg -f image2 -framerate 8 -i WORKDIR/hedwig/BASENAME_mp4.%04d.jpg -vcodec libx264 \
+                -pix_fmt yuv420p -s 1024,1024 WORKDIR/hedwig/keyMov_BASENAME.mp4
+
+    """
+    # gen_ave_jpgs_from_ave_mrc(ave_mrc=ave_mrc)
+    mp4_base = f"{ave_mrc.parent}/{ave_mrc.stem}_mp4"
+    mrc2tiff_log_file = f"{ave_mrc.parent}/recon_mrc2tiff.log"
+    mrc2tiff_cmd = [
+        BRTConfig.mrc2tif_loc,
+        "-j",
+        "-C",
+        "100,255",
+        ave_mrc.as_posix(),
+        mp4_base,
+    ]
+    FilePath.run(cmd=mrc2tiff_cmd, log_file=mrc2tiff_log_file)
+    # don't put the 's in here, as per docs. subprocess messes them up
+    jpg_input_pattern = f"{mp4_base}*.jpg"
+    key_mov = f"{ave_mrc.parent}/{ave_mrc.stem}_keyMov.mp4"
+    cmd = [
+        "ffmpeg",
+        "-f",
+        "image2",
+        "-pattern_type",
+        "glob",
+        "-framerate",
+        "8",
+        "-i",
+        jpg_input_pattern,
+        "-vcodec",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-s",
+        "1024,1024",
+        key_mov,
+    ]
+    log_file = f"{ave_mrc.parent}/{ave_mrc.stem}_keyMov.log"
+    FilePath.run(cmd=cmd, log_file=log_file)
+    cleanup_files(file_path=ave_mrc, pattern=("_mp4.*.jpg"))
+    return Path(key_mov)
+
+
+def gen_clip_avgs(in_fp: Path, z_dim: str) -> None:
     """
     - give _rec mrc file, generate a stack of mrcs, averaged to assist viewing.
     - produces base_ave001.mrc etc, base_ave002.mrc etc,
@@ -305,9 +405,8 @@ def gen_clip_avgs(file_path: FilePath, z_dim: str) -> None:
     for i in range(2, int(z_dim) - 2):
         izmin = i - 2
         izmax = i + 2
-        in_fp = f"{file_path.working_dir}/{file_path.base}_rec.mrc"
         padded_val = str(i).zfill(4)
-        ave_mrc = f"{file_path.working_dir}/{file_path.base}_ave{padded_val}.mrc"
+        ave_mrc = f"{in_fp.parent}/{in_fp.stem}_ave{padded_val}.mrc"
         min_max = f"{str(izmin)}-{str(izmax)}"
         cmd = [
             BRTConfig.clip_loc,
@@ -317,15 +416,14 @@ def gen_clip_avgs(file_path: FilePath, z_dim: str) -> None:
             min_max,
             "-m",
             "1",
-            in_fp,
+            in_fp.as_posix(),
             ave_mrc,
         ]
-        log_file = f"{file_path.working_dir}/clip_avg.error.log"
+        log_file = f"{in_fp.parent}/clip_avg.error.log"
         FilePath.run(cmd=cmd, log_file=log_file)
 
 
-@task
-def consolidate_ave_mrcs(file_path: FilePath) -> dict:
+def consolidate_ave_mrcs(fp_in: Path) -> Path:
     """
     - consumes base_ave001.mrc etc, base_ave002.mrc etc,
     - creates ave_base.mrc the (averagedVolume asset)
@@ -333,40 +431,33 @@ def consolidate_ave_mrcs(file_path: FilePath) -> dict:
 
         newstack -float 3 BASENAME_ave* ave_BASENAME.mrc
     """
-    aves = glob.glob(f"{file_path.working_dir}/{file_path.base}_ave*")
+    aves = glob.glob(f"{fp_in.parent}/{fp_in.stem}_ave*")
     aves.sort()
-    ave_mrc = f"{file_path.working_dir}/ave_{file_path.base}.mrc"
+    ave_mrc = Path(f"{fp_in.parent}/ave_{fp_in.stem}.mrc")
     cmd = [BRTConfig.newstack_loc, "-float", "3"]
     cmd.extend(aves)
-    cmd.append(ave_mrc)
-    log_file = f"{file_path.working_dir}/newstack_float.log"
+    cmd.append(ave_mrc.as_posix())
+    log_file = f"{fp_in.parent}/newstack_float.log"
     FilePath.run(cmd=cmd, log_file=log_file)
-    asset_fp = file_path.copy_to_assets_dir(fp_to_cp=Path(ave_mrc))
-    ave_vol_asset = file_path.gen_asset(
-        asset_type=AssetType.AVERAGED_VOLUME, asset_fp=asset_fp
-    )
-    return ave_vol_asset
+    cleanup_files(file_path=ave_mrc, pattern="*_ave*.mrc", keep_file=ave_mrc)
+    return ave_mrc
 
 
 @task
-def gen_ave_8_vol(file_path: FilePath) -> dict:
+def gen_ave_8_vol(ave_mrc: Path) -> Path:
     """
     - creates volume asset, for volslicer, eg::
 
         binvol -binning 2 WORKDIR/hedwig/ave_BASENAME.mrc WORKDIR/avebin8_BASENAME.mrc
     """
-    ave_8_mrc = f"{file_path.working_dir}/avebin8_{file_path.base}.mrc"
-    ave_mrc = f"{file_path.working_dir}/ave_{file_path.base}.mrc"
-    cmd = [BRTConfig.binvol, "-binning", "2", ave_mrc, ave_8_mrc]
-    log_file = f"{file_path.working_dir}/ave_8_mrc.log"
+    ave_8_mrc = f"{ave_mrc.parent}/avebin8_{ave_mrc.stem}.mrc"
+    cmd = [BRTConfig.binvol, "-binning", "2", ave_mrc.as_posix(), ave_8_mrc]
+    log_file = f"{ave_mrc.parent}/ave_8_mrc.log"
     FilePath.run(cmd=cmd, log_file=log_file)
-    asset_fp = file_path.copy_to_assets_dir(fp_to_cp=Path(ave_8_mrc))
-    bin_vol_asset = file_path.gen_asset(asset_type=AssetType.VOLUME, asset_fp=asset_fp)
-    return bin_vol_asset
+    return Path(ave_8_mrc)
 
 
-@task
-def gen_ave_jpgs_from_ave_mrc(file_path: FilePath):
+def gen_ave_jpgs_from_ave_mrc(ave_mrc: Path):
     """
     - generates a load of jpgs from the ave_base.mrc with the format {base}_mp4.123.jpg \
             **OR** {base}_mp4.1234.jpg depending on size of stack.
@@ -374,23 +465,23 @@ def gen_ave_jpgs_from_ave_mrc(file_path: FilePath):
 
         mrc2tif -j -C 100,255 WORKDIR/hedwig/ave_BASNAME.mrc hedwig/BASENAME_mp4
     """
-    mp4 = f"{file_path.working_dir}/{file_path.base}_mp4"
-    ave_mrc = f"{file_path.working_dir}/ave_{file_path.base}.mrc"
-    log_file = f"{file_path.working_dir}/recon_mrc2tiff.log"
-    cmd = [BRTConfig.mrc2tif_loc, "-j", "-C", "100,255", ave_mrc, mp4]
+    mp4 = f"{ave_mrc.parent}/{ave_mrc.stem}_mp4"
+    log_file = f"{ave_mrc.parent}/recon_mrc2tiff.log"
+    cmd = [BRTConfig.mrc2tif_loc, "-j", "-C", "100,255", ave_mrc.as_posix(), mp4]
     FilePath.run(cmd=cmd, log_file=log_file)
 
 
-@task
-def cleanup_files(file_path: FilePath, pattern=str):
+def cleanup_files(file_path: Path, pattern=str, keep_file: Path = None):
     """
     Given a ``FilePath`` and unix file ``pattern``, iterate through directory removing all files
     that match the pattern
     """
-    f = f"{file_path.working_dir.as_posix()}/{pattern}"
+    f = f"{file_path.parent.as_posix()}/{pattern}"
     utils.log(f"trying to rm {f}")
     files_to_rm = glob.glob(f)
     for _file in files_to_rm:
+        if keep_file and keep_file.as_posix() == _file:
+            continue
         os.remove(_file)
     print(files_to_rm)
 
@@ -440,40 +531,39 @@ def cleanup_files(file_path: FilePath, pattern=str):
 
 
 @task
-def gen_zarr(fp_in: FilePath):
-    file_path = fp_in
-    # fallback mrc file
-    input_file = file_path.fp_in.as_posix()
+def gen_zarr(brt_output: utils.BrtOutput) -> Path:
 
-    rec_mrc = file_path.gen_output_fp(output_ext="_rec.mrc")
-    if rec_mrc.is_file():
-        input_file = rec_mrc.as_posix()
+    if not brt_output.rec_file.is_file():
+        raise ValueError(f"{brt_output.rec_file} does not exist")
 
-    ng.bioformats_gen_zarr(
-        file_path=file_path,
-        input_fname=input_file,
+    output_zarr = ng.bioformats_gen_zarr_dup(
+        fp_in=brt_output.rec_file,
         depth=BRT_DEPTH,
         width=BRT_WIDTH,
         height=BRT_HEIGHT,
         resolutions=1,
     )
-    output_zarr = Path(f"{file_path.working_dir}/{file_path.base}.zarr")
-    file_path.copy_to_assets_dir(fp_to_cp=Path(output_zarr))
-
-    ng.zarr_build_multiscales(file_path)
+    ng.zarr_build_multiscales2(output_zarr)
+    return output_zarr
 
 
 @task
-def gen_ng_metadata(fp_in: FilePath) -> Dict:
+def copy_asset_gen_elt(file_path: FilePath, fp_to_cp: Path, asset_type: str) -> dict:
+    asset_fp = file_path.copy_to_assets_dir(fp_to_cp=fp_to_cp)
+    asset_elt = file_path.gen_asset(asset_type=asset_type, asset_fp=asset_fp)
+    return asset_elt
+
+
+@task
+def gen_ng_metadata(fp_in: FilePath, zarr: Path) -> Dict:
     # Note; the seemingly redundancy of working and asset fp here.
     # However asset fp is in the network file system and is deployed for access to the users
     # Working fp is actually used for getting the metadata
 
     file_path = fp_in
     asset_fp = Path(f"{file_path.assets_dir}/{file_path.base}.zarr")
-    working_fp = Path(f"{file_path.working_dir}/{file_path.base}.zarr")
     utils.log("Instantiating HWZarrImages")
-    hw_images = HedwigZarrImages(zarr_path=working_fp, read_only=False)
+    hw_images = HedwigZarrImages(zarr_path=zarr, read_only=False)
     utils.log("Accessing first HWZarrImage")
     hw_image = hw_images[list(hw_images.get_series_keys())[0]]
 
@@ -500,12 +590,24 @@ def gen_ng_metadata(fp_in: FilePath) -> Dict:
     return ng_asset
 
 
+@task
+def get_callback_result(callback_data: list) -> list:
+    cb_data = list()
+    for item in callback_data:
+        try:
+            json.dumps(item)
+            cb_data.append(item)
+        except TypeError:  # can't serialize the item
+            utils.log(f"Following item cannot be added to callback:\n\n{item}")
+    return cb_data
+
+
 # run_config=LocalRun(labels=[utils.get_environment()]),
 @flow(
     name="BRT",
     flow_run_name=utils.generate_flow_run_name,
     log_prints=True,
-    task_runner=BRTConfig.SLURM_EXECUTOR,
+    task_runner=BRTConfig.HIGH_SLURM_EXECUTOR,
     on_completion=[utils.notify_api_completion],
     on_failure=[utils.notify_api_completion],
 )
@@ -547,7 +649,7 @@ def brt_flow(
     fps = utils.gen_fps.submit(
         share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
     )
-    brts = utils.run_brt.map(
+    brt_outputs = utils.run_brt.map(
         file_path=fps,
         adoc_template=unmapped(adoc_template),
         montage=unmapped(montage),
@@ -562,97 +664,47 @@ def brt_flow(
     )
     # END BRT, check files for success (else fail here)
 
-    # stack dimensions - used in movie creation
-    # alignment z dimension, this is only used for the tilt movie.
-    ali_z_dims = gen_dimension_command.map(
-        file_path=fps,
-        ali_or_rec=unmapped("ali"),
-        wait_for=[allow_failure(brts)],
-        return_state=True,
+    tilt_movies = gen_tilt_movie_2.map(brt_outputs)
+    tilt_movie_assets = copy_asset_gen_elt.map(
+        file_path=fps, fp_to_cp=tilt_movies, asset_type=unmapped(AssetType.TILT_MOVIE)
     )
 
-    # START TILT MOVIE GENERATION:
-    ali_xs = gen_ali_x.map(
-        file_path=fps,
-        z_dim=ali_z_dims,
-        wait_for=[allow_failure(brts)],
-        return_state=True,
+    mid_images = find_middle_image.map(tilt_movies)
+    keyimg_assets = copy_asset_gen_elt.map(
+        file_path=fps, fp_to_cp=mid_images, asset_type=unmapped(AssetType.KEY_IMAGE)
     )
-    asmbls = gen_ali_asmbl.map(file_path=fps, wait_for=[allow_failure(ali_xs)])
-    mrc2tiffs = gen_mrc2tiff.map(file_path=fps, wait_for=[allow_failure(asmbls)])
-    thumb_assets = gen_thumbs.map(
-        file_path=fps, z_dim=ali_z_dims, wait_for=[allow_failure(mrc2tiffs)]
-    )
-    keyimg_assets = gen_copy_keyimages.map(
-        file_path=fps, z_dim=ali_z_dims, wait_for=[allow_failure(mrc2tiffs)]
-    )
-    tilt_movie_assets = gen_tilt_movie.map(
-        file_path=fps, wait_for=[allow_failure(keyimg_assets)]
-    )
-    cleanup_files.map(
-        file_path=fps,
-        pattern=unmapped("*_align_*.mrc"),
-        wait_for=[
-            allow_failure(tilt_movie_assets),
-            allow_failure(thumb_assets),
-            allow_failure(keyimg_assets),
-        ],
-    )
-    cleanup_files.map(
-        file_path=fps,
-        pattern=unmapped("*ali*.jpg"),
-        wait_for=[
-            allow_failure(tilt_movie_assets),
-            allow_failure(thumb_assets),
-            allow_failure(keyimg_assets),
-        ],
-    )
-    # END TILT MOVIE GENERATION
 
-    # START RECONSTR MOVIE GENERATION:
-    rec_z_dims = gen_dimension_command.map(
-        file_path=fps, ali_or_rec=unmapped("rec"), wait_for=[allow_failure(brts)]
+    thumbs = gen_thumbs.map(mid_images)
+    thumb_assets = copy_asset_gen_elt.map(
+        file_path=fps, fp_to_cp=thumbs, asset_type=unmapped(AssetType.THUMBNAIL)
     )
-    clip_avgs = gen_clip_avgs.map(
-        file_path=fps, z_dim=rec_z_dims, wait_for=[allow_failure(asmbls)]
-    )
-    averagedVolume_assets = consolidate_ave_mrcs.map(
-        file_path=fps, wait_for=[allow_failure(clip_avgs)]
-    )
-    ave_jpgs = gen_ave_jpgs_from_ave_mrc.map(
-        file_path=fps, wait_for=[allow_failure(averagedVolume_assets)]
-    )
-    recon_movie_assets = gen_recon_movie.map(
-        file_path=fps, wait_for=[allow_failure(ave_jpgs)]
-    )
-    cleanup_files.map(
-        file_path=fps,
-        pattern=unmapped("*_mp4.*.jpg"),
-        wait_for=[allow_failure(recon_movie_assets), allow_failure(ave_jpgs)],
-    )
-    cleanup_files.map(
-        file_path=fps,
-        pattern=unmapped("*_ave*.mrc"),
-        wait_for=[allow_failure(recon_movie_assets), allow_failure(ave_jpgs)],
-    )
-    #    # END RECONSTR MOVIE
 
+    ave_mrcs = gen_ave_mrc.map(brt_output=brt_outputs)
+    averagedVolume_assets = copy_asset_gen_elt.map(
+        file_path=fps, fp_to_cp=ave_mrcs, asset_type=unmapped(AssetType.VOLUME)
+    )
+
+    recon_movies = gen_recon_movie_2.map(ave_mrc=ave_mrcs)
+    recon_movie_assets = copy_asset_gen_elt.map(
+        file_path=fps, fp_to_cp=recon_movies, asset_type=unmapped(AssetType.REC_MOVIE)
+    )
     # Binned volume assets, for volslicer.
-    bin_vol_assets = gen_ave_8_vol.map(
-        file_path=fps, wait_for=[allow_failure(averagedVolume_assets)]
+    bin_vol_mrcs = gen_ave_8_vol.map(ave_mrc=ave_mrcs)
+    bin_vol_assets = copy_asset_gen_elt.map(
+        file_path=fps,
+        fp_to_cp=bin_vol_mrcs,
+        asset_type=unmapped(AssetType.AVERAGED_VOLUME),
     )
-    # finished volslicer inputs.
 
-    zarrs = gen_zarr.map(fp_in=fps, wait_for=[allow_failure(brts)])
-    pyramid_assets = gen_ng_metadata.map(fp_in=fps, wait_for=[allow_failure(zarrs)])
-    #  archive_pyramid_cmds = ng.gen_archive_pyr.map(
-    #      file_path=fps, wait_for=[pyramid_assets]
-    #  )
+    zarrs = gen_zarr.map(brt_output=brt_outputs)
+    pyramid_assets = gen_ng_metadata.map(fp_in=fps, zarr=zarrs)
 
     # now we've done the computational work.
     # the relevant files have been put into the Assets dirs, but we need to inform the API
     # Generate a base "primary path" dict, and hang dicts onto this.
     # repeatedly pass asset in to add_asset func to add asset in question.
+    # allow_failure in gen_fps because we want to include EVERY fp, not just OK ones
+    # prim_fps = utils.gen_prim_fps.map(fp_in=fps, wait_for=[allow_failure(brt_outputs)])
     prim_fps = utils.gen_prim_fps.map(fp_in=fps)
     callback_with_thumbs = utils.add_asset.map(prim_fp=prim_fps, asset=thumb_assets)
     callback_with_keyimgs = utils.add_asset.map(
@@ -673,25 +725,37 @@ def brt_flow(
     callback_with_tilt_mov = utils.add_asset.map(
         prim_fp=callback_with_recon_mov, asset=tilt_movie_assets
     )
-    copy_task = utils.copy_workdirs.map(
-        fps, wait_for=[allow_failure(callback_with_tilt_mov)]
-    )
+
+    for cb in callback_with_tilt_mov:
+        cb.wait()
+    copy_task = utils.copy_workdirs.map(file_path=fps)
     # This is to make sure that we wait for copy completes before cleanup
     for future in copy_task:
-        future.result()
-
-    utils.callback_with_cleanup(
-        fps=fps,
-        callback_result=callback_with_tilt_mov,
+        future.wait()
+    cb = utils.send_callback_body.submit(
         x_no_api=x_no_api,
-        callback_url=callback_url,
         token=token,
-        x_keep_workdir=x_keep_workdir,
+        callback_url=callback_url,
+        files_elts=callback_with_tilt_mov,
     )
+    utils.cleanup_workdir.submit(
+        fps,
+        x_keep_workdir,
+        wait_for=[copy_task],
+    )
+    # callback_result = get_callback_result.submit(callback_with_tilt_mov)
+    #    utils.callback_with_cleanup(
+    #        fps=fps,
+    #        callback_result=callback_result,
+    #        x_no_api=x_no_api,
+    #        callback_url=callback_url,
+    #        token=token,
+    #        x_keep_workdir=x_keep_workdir,
+    #    )
 
-    for zarr in zarrs:
+    for zarr in recon_movies:
         print(zarr.result())
-        if zarr.result() == "success":
+        if isinstance(zarr.result(), Path):
             return Completed(message="I am happy with this result")
     return Failed(message="How did this happen!?")
 

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -522,16 +522,23 @@ def brt_flow(
     x_keep_workdir: bool = False,
     adoc_template: str = "plastic_brt",
 ):
-    utils.notify_api_running(x_no_api, token, callback_url)
+    if x_no_api:
+        utils.notify_api_running.submit(x_no_api=x_no_api)
+    else:
+        utils.notify_api_running.submit(token=token, callback_url=callback_url)
 
     # a single input_dir will have n tomograms
-    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
+    input_dir_fp = utils.get_input_dir.submit(
+        share_name=file_share, input_dir=input_dir
+    )
     # input_dir_fp = utils.get_input_dir(input_dir=input_dir)
-    input_fps = utils.list_files(
+    input_fps = utils.list_files.submit(
         input_dir=input_dir_fp, exts=["MRC", "ST", "mrc", "st"], single_file=x_file_name
     )
 
-    fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
+    fps = utils.gen_fps.submit(
+        share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
+    )
     brts = utils.run_brt.map(
         file_path=fps,
         adoc_template=unmapped(adoc_template),

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -44,6 +44,7 @@ from typing import Optional
 from pathlib import Path
 
 from prefect import task, flow, unmapped, allow_failure
+from prefect.states import Completed, Failed
 from pytools.HedwigZarrImages import HedwigZarrImages
 
 from em_workflows.utils import utils
@@ -687,6 +688,12 @@ def brt_flow(
         token=token,
         x_keep_workdir=x_keep_workdir,
     )
+
+    for zarr in zarrs:
+        print(zarr.result())
+        if zarr.result() == "success":
+            return Completed(message="I am happy with this result")
+    return Failed(message="How did this happen!?")
 
     """
     # if the callback is not empty (that is one of the files passed), final=success

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -564,7 +564,10 @@ def brt_flow(
     # stack dimensions - used in movie creation
     # alignment z dimension, this is only used for the tilt movie.
     ali_z_dims = gen_dimension_command.map(
-        file_path=fps, ali_or_rec=unmapped("ali"), wait_for=[allow_failure(brts)]
+        file_path=fps,
+        ali_or_rec=unmapped("ali"),
+        wait_for=[allow_failure(brts)],
+        return_state=True,
     )
 
     # START TILT MOVIE GENERATION:

--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -238,9 +238,10 @@ async def czi_flow(
     fps = utils.gen_fps.submit(
         share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
     )
+    fp_results = fps.result()
     prim_fps = utils.gen_prim_fps.map(fp_in=fps)
     imageSets = await asyncio.gather(
-        *[generate_czi_imageset(file_path=fp) for fp in fps]
+        *[generate_czi_imageset(file_path=fp) for fp in fp_results]
     )
     callback_with_zarrs = utils.add_imageSet.map(prim_fp=prim_fps, imageSet=imageSets)
     callback_with_zarrs = update_file_metadata.map(

--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -221,10 +221,7 @@ async def czi_flow(
     x_no_api: bool = False,
     x_keep_workdir: bool = False,
 ):
-    if x_no_api:
-        utils.notify_api_running.submit(x_no_api=x_no_api)
-    else:
-        utils.notify_api_running.submit(token=token, callback_url=callback_url)
+    utils.notify_api_running(x_no_api, token, callback_url)
 
     input_dir_fp = utils.get_input_dir.submit(
         share_name=file_share, input_dir=input_dir

--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -221,14 +221,23 @@ async def czi_flow(
     x_no_api: bool = False,
     x_keep_workdir: bool = False,
 ):
-    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
+    if x_no_api:
+        utils.notify_api_running.submit(x_no_api=x_no_api)
+    else:
+        utils.notify_api_running.submit(token=token, callback_url=callback_url)
 
-    input_fps = utils.list_files(
+    input_dir_fp = utils.get_input_dir.submit(
+        share_name=file_share, input_dir=input_dir
+    )
+
+    input_fps = utils.list_files.submit(
         input_dir_fp,
         VALID_CZI_INPUTS,
         single_file=x_file_name,
     )
-    fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
+    fps = utils.gen_fps.submit(
+        share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
+    )
     prim_fps = utils.gen_prim_fps.map(fp_in=fps)
     imageSets = await asyncio.gather(
         *[generate_czi_imageset(file_path=fp) for fp in fps]

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -222,7 +222,10 @@ def dm_flow(
     -convert all mrcs in Projects dir to jpegs.
     -convert all tiffs/pngs/jpegs to correct size for thumbs, "sm" and "lg"
     """
-    utils.log("this is coming out of the flow")
+    if x_no_api:
+        utils.notify_api_running.submit(x_no_api=x_no_api)
+    else:
+        utils.notify_api_running.submit(token=token, callback_url=callback_url)
 
     # utils.log(input_dir)
     input_dir_fp = utils.get_input_dir.submit(

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -175,11 +175,6 @@ def scale_jpegs(file_path: FilePath, size: str) -> Optional[dict]:
     return asset_elt
 
 
-@flow(
-    name="SubFlow: Intermediate Convert",
-    log_prints=True,
-    task_runner=DMConfig.SLURM_EXECUTOR,
-)
 def convert_intermediate_files(fps):
     tif_fps = [
         fp

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -222,10 +222,7 @@ def dm_flow(
     -convert all mrcs in Projects dir to jpegs.
     -convert all tiffs/pngs/jpegs to correct size for thumbs, "sm" and "lg"
     """
-    if x_no_api:
-        utils.notify_api_running.submit(x_no_api=x_no_api)
-    else:
-        utils.notify_api_running.submit(token=token, callback_url=callback_url)
+    utils.notify_api_running(x_no_api, token, callback_url)
 
     # utils.log(input_dir)
     input_dir_fp = utils.get_input_dir.submit(
@@ -244,7 +241,7 @@ def dm_flow(
     # logs = utils.init_log.map(file_path=fps)
 
     # subflow calls are blocking, so lower task runs auto waits always
-    convert_intermediate_files(fps)
+    convert_intermediate_files(fps.result())
 
     # Finally generate all valid suffixed results
     keyimg_assets = scale_jpegs.map(fps, size=unmapped("l"))

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -230,19 +230,22 @@ def dm_flow(
     utils.log("this is coming out of the flow")
 
     # utils.log(input_dir)
-    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
+    input_dir_fp = utils.get_input_dir.submit(
+        share_name=file_share, input_dir=input_dir
+    )
 
-    input_fps = utils.list_files(
+    input_fps = utils.list_files.submit(
         input_dir_fp,
         VALID_2D_INPUT_EXTS,
         single_file=x_file_name,
     )
 
-    fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
+    fps = utils.gen_fps.submit(
+        share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
+    )
     # logs = utils.init_log.map(file_path=fps)
 
     # subflow calls are blocking, so lower task runs auto waits always
-    return
     convert_intermediate_files(fps)
 
     # Finally generate all valid suffixed results

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -227,6 +227,9 @@ def dm_flow(
     -convert all mrcs in Projects dir to jpegs.
     -convert all tiffs/pngs/jpegs to correct size for thumbs, "sm" and "lg"
     """
+    utils.log("this is coming out of the flow")
+
+    # utils.log(input_dir)
     input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
 
     input_fps = utils.list_files(
@@ -234,10 +237,12 @@ def dm_flow(
         VALID_2D_INPUT_EXTS,
         single_file=x_file_name,
     )
+
     fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
     # logs = utils.init_log.map(file_path=fps)
 
     # subflow calls are blocking, so lower task runs auto waits always
+    return
     convert_intermediate_files(fps)
 
     # Finally generate all valid suffixed results

--- a/em_workflows/file_path.py
+++ b/em_workflows/file_path.py
@@ -173,7 +173,7 @@ class FilePath:
         asset = {"type": asset_type, "path": assets_fp_no_root.as_posix()}
         return asset
 
-    def gen_prim_fp_elt(self) -> Dict:
+    def gen_prim_fp_elt(self, exceptions_as_str: str = None) -> Dict:
         """
         creates a single primaryFilePath element, to which assets can be appended.
 
@@ -209,8 +209,15 @@ class FilePath:
             "assets": assets,
         }
         imageSet = [imageSetElement]
+        status = "success"
+        message = None
+        if exceptions_as_str:
+            status = "error"
+            message = exceptions_as_str
         return dict(
             primaryFilePath=primaryFilePath.as_posix(),
+            status=status,
+            message=message,
             thumbnailIndex=thumbnailIndex,
             title=title,
             fileMetadata=fileMetadata,

--- a/em_workflows/lrg_2d_rgb/flow.py
+++ b/em_workflows/lrg_2d_rgb/flow.py
@@ -157,10 +157,7 @@ def lrg_2d_flow(
     -create tmp dir for each.
     -convert to tiff -> zarr -> jpegs (thumb)
     """
-    if x_no_api:
-        utils.notify_api_running.submit(x_no_api=x_no_api)
-    else:
-        utils.notify_api_running.submit(token=token, callback_url=callback_url)
+    utils.notify_api_running(x_no_api, token, callback_url)
 
     input_dir_fp = utils.get_input_dir.submit(
         share_name=file_share, input_dir=input_dir

--- a/em_workflows/lrg_2d_rgb/flow.py
+++ b/em_workflows/lrg_2d_rgb/flow.py
@@ -158,18 +158,22 @@ def lrg_2d_flow(
     -convert to tiff -> zarr -> jpegs (thumb)
     """
     if x_no_api:
-        utils.notify_api_running(x_no_api=x_no_api)
+        utils.notify_api_running.submit(x_no_api=x_no_api)
     else:
-        utils.notify_api_running(token=token, callback_url=callback_url)
+        utils.notify_api_running.submit(token=token, callback_url=callback_url)
 
-    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
+    input_dir_fp = utils.get_input_dir.submit(
+        share_name=file_share, input_dir=input_dir
+    )
 
-    input_fps = utils.list_files(
+    input_fps = utils.list_files.submit(
         input_dir_fp,
         VALID_LRG_2D_RGB_INPUTS,
         single_file=x_file_name,
     )
-    fps = utils.gen_fps(share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps)
+    fps = utils.gen_fps.submit(
+        share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
+    )
     tiffs = convert_png_to_tiff.map(file_path=fps)
     zarrs = gen_zarr.map(file_path=fps, wait_for=[tiffs])
     rechunk = rechunk_zarr.map(file_path=fps, wait_for=[zarrs])

--- a/em_workflows/sem_tomo/flow.py
+++ b/em_workflows/sem_tomo/flow.py
@@ -316,10 +316,7 @@ def sem_tomo_flow(
     x_keep_workdir: bool = False,
     tilt_angle: float = 0,
 ):
-    if x_no_api:
-        utils.notify_api_running.submit(x_no_api=x_no_api)
-    else:
-        utils.notify_api_running.submit(token=token, callback_url=callback_url)
+    utils.notify_api_running(x_no_api, token, callback_url)
 
     input_dir_fp = utils.get_input_dir.submit(
         share_name=file_share, input_dir=input_dir

--- a/em_workflows/sem_tomo/flow.py
+++ b/em_workflows/sem_tomo/flow.py
@@ -316,13 +316,20 @@ def sem_tomo_flow(
     x_keep_workdir: bool = False,
     tilt_angle: float = 0,
 ):
-    input_dir_fp = utils.get_input_dir(share_name=file_share, input_dir=input_dir)
+    if x_no_api:
+        utils.notify_api_running.submit(x_no_api=x_no_api)
+    else:
+        utils.notify_api_running.submit(token=token, callback_url=callback_url)
+
+    input_dir_fp = utils.get_input_dir.submit(
+        share_name=file_share, input_dir=input_dir
+    )
     # note FIBSEM is different to other flows in that it uses *directories*
     # to define stacks. Therefore, will have to list dirs to discover stacks
     # (rather than eg mrc files)
-    input_dir_fps = utils.list_dirs(input_dir_fp=input_dir_fp)
+    input_dir_fps = utils.list_dirs.submit(input_dir_fp=input_dir_fp)
 
-    fps = utils.gen_fps(
+    fps = utils.gen_fps.submit(
         share_name=file_share, input_dir=input_dir_fp, fps_in=input_dir_fps
     )
     tif_to_mrc = convert_tif_to_mrc.map(fps)

--- a/em_workflows/utils/neuroglancer.py
+++ b/em_workflows/utils/neuroglancer.py
@@ -17,6 +17,56 @@ def rechunk_zarr(file_path: FilePath) -> None:
         image.rechunk(RECHUNK_SIZE, in_memory=True)
 
 
+def bioformats_gen_zarr_dup(
+    fp_in: Path,
+    rechunk: bool = False,
+    width: int = None,
+    height: int = None,
+    resolutions: int = None,
+    depth: int = None,
+):
+    """
+    Following params alter based on what kind of flow is running...
+
+    :param input_fname: Depending on the flow, input fname might be different
+    :param rechunk: Rechunk zarrs if required
+    :param width:
+    :param height:
+    :param resolutions:
+    :param depth: These arguments are only used by BRT and SEM flows
+    """
+    output_zarr = f"{fp_in.parent}/{fp_in.stem}.zarr"
+    log_fp = f"{fp_in.parent}/{fp_in.stem}_as_zarr.log"
+    cmd = [
+        Config.bioformats2raw,
+        f"--max_workers={BIOFORMATS_NUM_WORKERS}",
+        "--overwrite",
+        "--compression",
+        "blosc",
+        "--compression-properties",
+        "cname=zstd",
+        "--compression-properties",
+        "clevel=5",
+        "--compression-properties",
+        "shuffle=1",
+    ]
+    if resolutions is not None:
+        cmd.extend(["--resolutions", str(resolutions)])
+    if width is not None:
+        cmd.extend(["--tile_width", str(width)])
+    if height is not None:
+        cmd.extend(["--tile_height", str(height)])
+
+    if depth:
+        cmd.extend(["--chunk_depth", str(depth)])
+    else:
+        cmd.extend(["--downsample-type", "AREA"])
+
+    cmd.extend([fp_in.as_posix(), output_zarr])
+    FilePath.run(cmd=cmd, log_file=log_fp)
+    return Path(output_zarr)
+
+
 def bioformats_gen_zarr(
     file_path: FilePath,
     input_fname: str,
@@ -70,6 +120,15 @@ def bioformats_gen_zarr(
 def zarr_build_multiscales(file_path: FilePath) -> None:
     zarr = Path(f"{file_path.assets_dir}/{file_path.base}.zarr/0")
     log_file = f"{file_path.working_dir}/{file_path.base}.log"
+
+    utils.log("Building multiscales...")
+    cmd_ms = ["zarr_build_multiscales", zarr.as_posix()]
+    FilePath.run(cmd=cmd_ms, log_file=log_file)
+
+
+def zarr_build_multiscales2(zarr_fp: Path) -> None:
+    zarr = zarr_fp / "0"
+    log_file = f"{zarr_fp.parent}/{zarr_fp.stem}.log"
 
     utils.log("Building multiscales...")
     cmd_ms = ["zarr_build_multiscales", zarr.as_posix()]

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -660,16 +660,16 @@ def callback_with_cleanup(
 ):
     cp_wd_logs_to_assets = copy_workdir_logs.map(fps, wait_for=[callback_result])
 
-    cb = send_callback_body(
+    cb = send_callback_body.submit(
         x_no_api=x_no_api,
         token=token,
         callback_url=callback_url,
         files_elts=callback_result,
     )
-    cleanup_workdir(
+    cleanup_workdir.submit(
         fps,
         x_keep_workdir,
-        wait_for=[allow_failure(cb), allow_failure(cp_wd_logs_to_assets)],
+        wait_for=[cb, allow_failure(cp_wd_logs_to_assets)],
     )
 
 

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -19,6 +19,7 @@ from em_workflows.file_path import FilePath
 
 # used for keeping outputs of imod's header command (dimensions of image).
 Header = namedtuple("Header", "x y z")
+BrtOutput = namedtuple("BrtOutput", ["ali_file", "rec_file"])
 
 
 def log(msg):
@@ -109,6 +110,7 @@ def mrc_to_movie(file_path: FilePath, root: str, asset_type: str):
 def gen_prim_fps(fp_in: FilePath) -> Dict:
     """
     :param fp_in: FilePath of current input
+    :outputs_with_exceptions this func is called with allow_failure - important
     :return: a Dict to hold the 'assets'
 
     This function delegates creation of primary fps to ``FilePath.gen_prim_fp_elt()``
@@ -307,7 +309,7 @@ def run_brt(
     TargetNumberOfBeads: int,
     LocalAlignments: int,
     THICKNESS: int,
-) -> None:
+) -> BrtOutput:
     """
     The natural place for this function is within the brt flow.
     The reason for this is to facilitate testing. In prefect 1, a
@@ -347,23 +349,7 @@ def run_brt(
     for _file in [rec_file, ali_file]:
         if not _file.exists():
             raise ValueError(f"File {_file} does not exist. BRT run failure.")
-    # brts_ok = check_brt_run_ok(file_path=file_path)
-
-
-# def check_brt_run_ok(file_path: FilePath):
-#     """
-#     ensures the following files exist:
-#     BASENAME_rec.mrc - the source for the reconstruction movie
-#     and Neuroglancer pyramid
-#     BASENAME_ali.mrc
-#     """
-#     rec_file = Path(f"{file_path.working_dir}/{file_path.base}_rec.mrc")
-#     ali_file = Path(f"{file_path.working_dir}/{file_path.base}_ali.mrc")
-#     log(f"checking that dir {file_path.working_dir} contains ok BRT run")
-#
-#     for _file in [rec_file, ali_file]:
-#         if not _file.exists():
-#             raise signals.FAIL(f"File {_file} does not exist. BRT run failure.")
+    return BrtOutput(ali_file=ali_file, rec_file=rec_file)
 
 
 # TODO replace "trigger=always_run"

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -522,8 +522,8 @@ def notify_api_completion(flow: Flow, flow_run: FlowRun, state: State):
     https://docs.prefect.io/core/concepts/states.html#overview.
     https://docs.prefect.io/core/concepts/notifications.html#state-handlers
     """
-    status = "Completed" if state.is_completed else "Failed"
-    x_no_api = flow_run.parameters.get("x_no_api", True)
+    status = "success" if state.is_completed() else "error"
+    x_no_api = flow_run.parameters.get("x_no_api", False)
     token = flow_run.parameters.get("token", "")
     callback_url = flow_run.parameters.get("callback_url", "")
 
@@ -539,11 +539,15 @@ def notify_api_completion(flow: Flow, flow_run: FlowRun, state: State):
         callback_url, headers=headers, data=json.dumps({"status": status})
     )
     log(f"Pipeline status is:{status}")
+    print(f"Pipeline status is:{status}")
     log(response.text)
+    print(response.text)
     log(response.headers)
+    print(response.headers)
     if not response.ok:
         msg = f"Bad response code on callback: {response}"
         log(msg=msg)
+        print(msg=msg)
         raise RuntimeError(msg)
     return response.ok
 

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -346,7 +346,7 @@ def run_brt(
 
     for _file in [rec_file, ali_file]:
         if not _file.exists():
-            raise RuntimeError(f"File {_file} does not exist. BRT run failure.")
+            raise ValueError(f"File {_file} does not exist. BRT run failure.")
     # brts_ok = check_brt_run_ok(file_path=file_path)
 
 
@@ -531,12 +531,11 @@ def notify_api_completion(flow: Flow, flow_run: FlowRun, state: State):
 
     flowrun_id = os.environ.get("PREFECT__FLOW_RUN_ID", "not-found")
 
-    hooks_log = open(f"slurm-log/{flowrun_id}-notify-api-completion.txt", "w")
     if x_no_api:
         log(f"x_no_api flag used\nCompletion status: {status}")
-        hooks_log.close()
         return
 
+    hooks_log = open(f"slurm-log/{flowrun_id}-notify-api-completion.txt", "w")
     hooks_log.write(f"Trying to notify: {x_no_api=}, {token=}, {callback_url=}\n")
 
     headers = {

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -576,12 +576,17 @@ def get_input_dir(share_name: str, input_dir: str) -> Path:
     | create working dir
     | returns Path obj
     """
+    log("this is really dumb - in input_dir")
     if not input_dir.endswith("/"):
         input_dir = input_dir + "/"
     if not input_dir.startswith("/"):
         input_dir = "/" + input_dir
     input_path_str = Config.proj_dir(share_name=share_name) + input_dir
-    return Path(input_path_str)
+    p = Path(input_path_str)
+    log(f"Checking input dir {p.as_posix()} which exists? {p.exists()}")
+    if not p.exists():
+        raise RuntimeError(f"Fail get_input_dir, {p.as_posix()} does not exist")
+    return p
 
 
 @task
@@ -591,7 +596,9 @@ def gen_fps(share_name: str, input_dir: Path, fps_in: List[Path]) -> List[FilePa
     a list of FilePaths for the input files. This includes a temporary working
     directory for each file to keep the files separate on the HPC.
     """
+    log("Creating FPS...")
     fps = list()
+    return fps
     for fp in fps_in:
         file_path = FilePath(share_name=share_name, input_dir=input_dir, fp_in=fp)
         msg = f"created working_dir {file_path.working_dir} for {fp.as_posix()}"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,6 +21,7 @@ def mock_binaries(monkeypatch):
 
     monkeypatch.setattr(Config, "tmp_dir", "/tmp")
     monkeypatch.setattr(Config, "SLURM_EXECUTOR", ConcurrentTaskRunner())
+    monkeypatch.setattr(Config, "HIGH_SLURM_EXECUTOR", ConcurrentTaskRunner())
 
 
 @pytest.fixture

--- a/test/test_brt.py
+++ b/test/test_brt.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 @pytest.mark.localdata
 @pytest.mark.slow
-def test_brt(mock_nfs_mount):
+def test_brt_p(mock_nfs_mount):
     from em_workflows.brt.flow import brt_flow
 
     input_dir = "test/input_files/brt/Projects/RT_TOMO/"


### PR DESCRIPTION
### Changes

* Add `notify api running` calls as soon as the flow runs start
* Remove subflow for small dm conversion flow
* Revert `Completion/Failed` to original `success/error` api calls on notify-api-completion
* Refactor BRT flow: combine tasks

### This PR doesn't introduce any:

- [x] Binary files
- [ ] Temporary files, auto-generated files
- [x] Secret keys
- [ ] Local debugging `print` statements
- [ ] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [ ] tests
