### PR TITLE
Feature/newstack 16 bit tiff

### DIFF
--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -85,8 +85,9 @@ def convert_if_int16_tiff(file_path: FilePath) -> None:
         "6",
         "-mode",
         "0",
-        "-meansd",
-        "140,50",
+        # From the newstack manual for "-float": Enter 1 for each section to fill the data range.
+        "-float",
+        "1",
         file_path.fp_in.as_posix(),
         str(tif_8_bit),
     ]


### PR DESCRIPTION
Replace meanstd with float 1 for 16-bit TIFF

When float 1 is used in conjunction with shrink, the range is computed
after the anti-aliasing and down-samping is performed. The resampling
suppresses the outliers ( pixel stuck on ), from overly effecting the
results.

The mean standard intensity normalization produce poor results for bimodal
images, where the blacks were too bright.