### PR TITLE
Add GraphicMagic as a configurable executable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,5 +10,6 @@ CONVERT_LOC=/usr/bin/convert
 TIF2MRC_LOC=/usr/local/IMOD/bin/tif2mrc
 XFALIGN_LOC=/usr/local/IMOD/bin/xfalign
 XFTOXG_LOC=/usr/local/IMOD/bin/xftoxg
+GM_LOC=/usr/bin/gm
 USER=test
 HEDWIG_ENV=dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           make -C docs html
       - name: Upload documentation
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: sphinx-docs
           path: docs/_build/html

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -34,6 +34,7 @@ Our pipelines rely on a number of freely available utilities:
 - `IMOD <https://bio3d.colorado.edu/imod/>`_
 - `bioformats2raw <https://github.com/glencoesoftware/bioformats2raw>`_
 - `imagemagick: <https://imagemagick.org/script/download.php>`_
+- `GraphicsMagick: <http://www.graphicsmagick.org>`_  Can be installed from condaforge.
 
 .. note::
    The ``.env`` file
@@ -68,7 +69,7 @@ Note, the container will need an `.env` file similar to any other environment. T
 to achieve this is copying the existing example file `.env.sample` to `.env`, this should work
 within the container as is.
 
-To build the docker image, use `--platform linux/amd63` option.
+To build the docker image, use `--platform linux/amd64` option.
 Explanation can be found `here <https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.wiki/tab::4f55363b-bb53-4e5b-9564-8bed5289fdd5?context=%7B%22subEntityId%22%3A%22%7B%5C%22pageId%5C%22%3A15%2C%5C%22sectionId%5C%22%3A17%2C%5C%22origin%5C%22%3A2%7D%22%2C%22channelId%22%3A%2219%3A869be6677ee54848bc13f2066d847cc0%40thread.skype%22%7D&tenantId=14b77578-9773-42d5-8507-251ca2dc2b06>`_
 
 The basic usage for testing would look like below. The command assumes that you are running the container from the project directory where the main Dockerfile is located.

--- a/em_workflows/brt/flow.py
+++ b/em_workflows/brt/flow.py
@@ -146,7 +146,7 @@ def gen_thumbs(middle_i_jpg: Path) -> Path:
     """
     thumb = f"{middle_i_jpg.parent}/keyimg_{middle_i_jpg.stem}_s.jpg"
     cmd = [
-        "gm",
+        BRTConfig.gm_loc,
         "convert",
         "-size",
         "300x300",

--- a/em_workflows/config.py
+++ b/em_workflows/config.py
@@ -83,6 +83,10 @@ class Config:
     mrc2tif_loc = os.environ.get("MRC2TIF_LOC", f"{imod_root}/bin/mrc2tif")
     newstack_loc = os.environ.get("NEWSTACK_LOC", f"{imod_root}/bin/newstack")
 
+    # Location of GraphicsMagick binary
+    #
+    gm_loc = os.environ.get("GM_LOC", "/usr/bin/gm")
+
     HIGH_SLURM_EXECUTOR = DaskTaskRunner(
         cluster_class=SLURM_exec,
         cluster_kwargs=dict(

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -193,7 +193,7 @@ def scale_jpegs(file_path: FilePath, size: str) -> Optional[dict]:
         log = f"{output.parent}/jpeg_sm.log"
         asset_type = AssetType.THUMBNAIL
         cmd = [
-            "gm",
+            DMConfig.gm_loc,
             "convert",
             "-size",
             SMALL_2D,
@@ -211,7 +211,7 @@ def scale_jpegs(file_path: FilePath, size: str) -> Optional[dict]:
         log = f"{output.parent}/jpeg_lg.log"
         asset_type = AssetType.KEY_IMAGE
         cmd = [
-            "gm",
+            DMConfig.gm_loc,
             "convert",
             "-size",
             LARGE_2D,


### PR DESCRIPTION
Addresses (eg: #1)

Depends on (eg: #1)

### Changes

* List of changes
* Breaking changes
* Changes to configurations

### This PR doesn't introduce any:

- [ ] Binary files
- [ ] Temporary files, auto-generated files
- [ ] Secret keys
- [ ] Local debugging `print` statements
- [ ] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [ ] tests
