### PR TITLE
DM convert refactor

### DIFF
--- a/docs/source/api/dm_conversion/flow.rst
+++ b/docs/source/api/dm_conversion/flow.rst
@@ -5,9 +5,11 @@ DM conversion flow
    :members:
    :undoc-members:
    :show-inheritance:
+    :ignore-module-all:
 
-   .. autofunction:: convert_dms_to_mrc(file_path: FilePath) -> None
-   .. autofunction:: convert_if_int16_tiff(file_path: FilePath) -> None
-   .. autofunction:: convert_2d_mrc_to_tiff(file_path: FilePath) -> None
-   .. autofunction:: convert_dm_mrc_to_jpeg(file_path: FilePath) -> None
-   .. autofunction:: scale_jpegs(file_path: FilePath, size: str) -> Optional[dict]
+   .. autofunction:: dm_flow
+   .. autofunction:: _calculate_shrink_factor
+   .. autofunction:: _newstack_mrc_to_tiff
+   .. autofunction:: _write_image_as_size
+   .. autofunction:: convert_em_to_tiff
+   .. autofunction:: generate_jpegs

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -27,7 +27,7 @@ from em_workflows.dm_conversion.constants import (
 
 def _calculate_shrink_factor(filepath: Path, enforce_2d: bool = True, target_size: int = LARGE_DIM) -> float:
     """
-    Calculate the shrink factor for the newstack command
+    Calculate the shrink factor for the newstack command to produce an image of the target size on the largest dimension.
     """
     dims = utils.lookup_dims(filepath)
 
@@ -35,10 +35,10 @@ def _calculate_shrink_factor(filepath: Path, enforce_2d: bool = True, target_siz
         msg = f"mrc file {filepath} is not 2 dimensional. Contains {dims.z} Z dims."
         raise RuntimeError(msg)
 
-    # use the min dimension of x & y to compute shrink_factor
-    min_xy = min(dims.x, dims.y)
-    # work out shrink_factor to make the resulting image LARGE_DIM
-    return min_xy / target_size
+    # use the max dimension of x & y to compute shrink_factor
+    max_xy = max(dims.x, dims.y)
+    # work out shrink_factor to make the resulting image LARGE_DIM at max
+    return max_xy / target_size
 
 
 def _newstack_mrc_to_tiff(input_fn: Path, output_fn: Path, log_fn: Path, use_float=True, verbose=False) -> None:

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -82,10 +82,11 @@ def _newstack_mrc_to_tiff(input_fn: Path, output_fn: Path, log_fn: Path, use_flo
 )
 def convert_em_to_tiff(file_path: FilePath) -> FilePath:
 
+    out_fp = file_path.gen_output_fp(output_ext="_as_tiff.tiff")
+    log_fp = file_path.gen_output_fp(output_ext="_as_tiff.log")
+
     if file_path.fp_in.suffix.strip(".").lower() in MRCS_EXT:
 
-        out_fp = file_path.gen_output_fp(out_fname="_as_tiff.tiff")
-        log_fp = file_path.working_dir/f"{file_path.base}_as_tiff.log"
         utils.log(f"{file_path.fp_in.as_posix()} is a mrc file, will convert to {out_fp}.")
 
         _newstack_mrc_to_tiff(file_path.fp_in, out_fp, log_fp, use_float=False)
@@ -95,22 +96,19 @@ def convert_em_to_tiff(file_path: FilePath) -> FilePath:
             and is_16bit(file_path.fp_in)
     ):
 
-        tif_8_bit = file_path.gen_output_fp(out_fname="_as_tiff.tif")
-        log_fp = file_path.working_dir/f"{file_path.base}_as_tiff.log"
-        utils.log(f"{file_path.fp_in} is a 16 bit tiff, converting to {tif_8_bit}")
+        utils.log(f"{file_path.fp_in} is a 16 bit tiff, converting to {out_fp}")
 
-        _newstack_mrc_to_tiff(file_path.fp_in, tif_8_bit, log_fp, use_float=True)
+        _newstack_mrc_to_tiff(file_path.fp_in, out_fp, log_fp, use_float=True)
 
     elif file_path.fp_in.suffix.strip(".").lower() in DMS_EXT:
-        dm_as_mrc = file_path.gen_output_fp(out_fname="dm_as_mrc.mrc")
+        dm_as_mrc = file_path.gen_output_fp(output_ext="dm_as_mrc.mrc")
         utils.log(msg=f"{file_path.fp_in} is a dm file, will convert to {dm_as_mrc}.")
-        log_file = file_path.working_dir/"dm2mrc.log"
+
+        mrc_log_fp = file_path.gen_output_fp(output_ext="_dm2mrc.log")
 
         cmd = [DMConfig.dm2mrc_loc, file_path.fp_in.as_posix(), dm_as_mrc.as_posix()]
-        FilePath.run(cmd=cmd, log_file=str(log_file))
+        FilePath.run(cmd=cmd, log_file=str(mrc_log_fp))
 
-        out_fp = file_path.working_dir/f"{file_path.base}_as_tiff.tiff"
-        log_fp = file_path.working_dir/f"{file_path.base}_as_tiff.log"
         utils.log(f"{dm_as_mrc} convert to {out_fp}.")
 
         _newstack_mrc_to_tiff(dm_as_mrc, out_fp, log_fp, use_float=True)

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -132,6 +132,8 @@ def sitk_scale_jpegs(file_path: FilePath) -> (dict, dict):
 
     """
 
+    convert_em_to_tiff.fn(file_path)
+
     small_size = (SMALL_DIM, )*2
     large_size = (LARGE_DIM, )*2
 
@@ -149,7 +151,9 @@ def sitk_scale_jpegs(file_path: FilePath) -> (dict, dict):
 
     output_small = file_path.gen_output_fp(output_ext="_SM.jpeg")
 
+    utils.log(msg=f"Reading {cur}...")
     img = sitk.ReadImage(cur)
+    utils.log(msg=f"Generating {img.GetSize()}->{small_size} {output_small}...")
     small_img = sitkutils.resize(img, small_size, sitk.sitkLinear)
     sitk.WriteImage(small_img, output_small, useCompression=True, compressionLevel=70)
     asset_type = AssetType.THUMBNAIL
@@ -157,6 +161,8 @@ def sitk_scale_jpegs(file_path: FilePath) -> (dict, dict):
     asset_small_elt = file_path.gen_asset(asset_type=asset_type, asset_fp=asset_small_fp)
 
     output_large = file_path.gen_output_fp(output_ext="_LG.jpeg")
+
+    utils.log(msg=f"Generating {img.GetSize()}->{large_size} {output_large}...")
     large_img = sitkutils.resize(img, large_size, sitk.sitkLinear)
     sitk.WriteImage(large_img, output_large, useCompression=True, compressionLevel=80)
 
@@ -220,11 +226,10 @@ def dm_flow(
         share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
     )
 
-    tiff_results = convert_em_to_tiff.map(file_path=fps)
+    #tiff_results = convert_em_to_tiff.map(file_path=fps)
 
     jpeg_assets = sitk_scale_jpegs.map(
-        fps,
-        wait_for=[allow_failure(tiff_results), allow_failure(tiff_results)],
+        fps
     )
 
     prim_fps = utils.gen_prim_fps.map(fp_in=fps, additional_assets=jpeg_assets)

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -146,9 +146,6 @@ def sitk_scale_jpegs(file_path: FilePath) -> (dict, dict):
         msg = f"Impossible state for {file_path.fp_in}"
         raise RuntimeError(msg)
 
-
-    log = file_path.gen_output_fp(output_ext="_jpeg.log")
-
     output_small = file_path.gen_output_fp(output_ext="_SM.jpeg")
 
     utils.log(msg=f"Reading {cur}...")
@@ -169,7 +166,8 @@ def sitk_scale_jpegs(file_path: FilePath) -> (dict, dict):
     asset_type = AssetType.KEY_IMAGE
     asset_large_fp = file_path.copy_to_assets_dir(fp_to_cp=output_large)
     asset_large_elt = file_path.gen_asset(asset_type=asset_type, asset_fp=asset_large_fp)
-    return asset_small_elt, asset_large_elt
+
+    return utils.gen_prim_fps.fn(fp_in=file_path, additional_assets=(asset_small_elt, asset_large_elt))
 
 
 @flow(
@@ -226,13 +224,7 @@ def dm_flow(
         share_name=file_share, input_dir=input_dir_fp, fps_in=input_fps
     )
 
-    #tiff_results = convert_em_to_tiff.map(file_path=fps)
-
-    jpeg_assets = sitk_scale_jpegs.map(
-        fps
-    )
-
-    prim_fps = utils.gen_prim_fps.map(fp_in=fps, additional_assets=jpeg_assets)
+    prim_fps = sitk_scale_jpegs.map( fps )
 
     callback_result = list()
     for idx, (fp, cb) in enumerate(zip(fps.result(), prim_fps)):

--- a/em_workflows/dm_conversion/flow.py
+++ b/em_workflows/dm_conversion/flow.py
@@ -41,7 +41,7 @@ def _calculate_shrink_factor(filepath: Path, enforce_2d: bool = True, target_siz
     return min_xy / target_size
 
 
-def _newstack_mrc_to_tiff(input_fn: Path, output_fn: Path, log_fn: Path, use_float=True) -> None:
+def _newstack_mrc_to_tiff(input_fn: Path, output_fn: Path, log_fn: Path, use_float=True, verbose=False) -> None:
     """
     Convert mrc files to tiff using newstack while reducing the size of the image, and performing antialiasing suitable
     for EM images.
@@ -54,6 +54,7 @@ def _newstack_mrc_to_tiff(input_fn: Path, output_fn: Path, log_fn: Path, use_flo
     :param use_float: If true uses the newstack "float" option to  fill the data range of the output. This range is
       computed after the shrink operation. If false, uses the "meansd" option with the default values of 140,50, which
       computed before the shrink operation.
+    :param verbose: If true, the newstack command is run in normal mode. Otherwise, quiet mode is enabled.
     :return:
     """
 
@@ -68,6 +69,9 @@ def _newstack_mrc_to_tiff(input_fn: Path, output_fn: Path, log_fn: Path, use_flo
         "-mode",
         "0",
         ]
+
+    if not verbose:
+        cmd.append("-quiet")
 
     if use_float:
         cmd.extend(["-float", "1"])

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -144,8 +144,9 @@ def gen_prim_fps(fp_in: FilePath, additional_assets:(dict, ...)=None) -> Dict:
     base_elts = fp_in.gen_prim_fp_elt()
     log(f"Generated fp elt {base_elts}")
 
-    for asset in additional_assets:
-        add_asset.fn(base_elts, asset)
+    if additional_assets:
+        for asset in additional_assets:
+            add_asset.fn(base_elts, asset)
 
     return base_elts
 

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -131,9 +131,10 @@ def mrc_to_movie(file_path: FilePath, root: str, asset_type: str, **kwargs):
 
 
 @task
-def gen_prim_fps(fp_in: FilePath) -> Dict:
+def gen_prim_fps(fp_in: FilePath, additional_assets:(dict, ...)=None) -> Dict:
     """
     :param fp_in: FilePath of current input
+    :param additional_assets: A list of additional assets to be added to the primary element
     :outputs_with_exceptions this func is called with allow_failure - important
     :return: a Dict to hold the 'assets'
 
@@ -142,6 +143,10 @@ def gen_prim_fps(fp_in: FilePath) -> Dict:
     """
     base_elts = fp_in.gen_prim_fp_elt()
     log(f"Generated fp elt {base_elts}")
+
+    for asset in additional_assets:
+        add_asset(base_elts, asset)
+
     return base_elts
 
 

--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -145,7 +145,7 @@ def gen_prim_fps(fp_in: FilePath, additional_assets:(dict, ...)=None) -> Dict:
     log(f"Generated fp elt {base_elts}")
 
     for asset in additional_assets:
-        add_asset(base_elts, asset)
+        add_asset.fn(base_elts, asset)
 
     return base_elts
 


### PR DESCRIPTION
Refactor the dm_convert pipeline.

Create a function to convert mrc to tiff files with newstack

Replace dm->jpeg step with newstack function.

Move separate "conditional" tasks into one function.

Addresses (eg: #1)

Depends on (eg: #1)

### Changes

* List of changes
* Breaking changes
* Changes to configurations

### This PR doesn't introduce any:

- [ ] Binary files
- [ ] Temporary files, auto-generated files
- [ ] Secret keys
- [ ] Local debugging `print` statements
- [ ] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [ ] tests
