### PR TITLE
Update to pytools 3.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ prefect==2.19.1
 prefect_dask==0.2.9
 dask-jobqueue==0.8.5
 natsort
-pytools@https://github.com/niaid/tomojs-pytools/releases/download/v3.3.1/pytools-3.3.1-py3-none-any.whl
+pytools@https://github.com/niaid/tomojs-pytools/releases/download/v3.3.2/pytools-3.3.2-py3-none-any.whl
 griffe==0.42


### PR DESCRIPTION
This update include support for detected H&E czi images as RGB, and single channel DAPI czi images as needing multi-channel shader.

Addresses (eg: #1)

Depends on (eg: #1)

### Changes

* List of changes
* Breaking changes
* Changes to configurations

### This PR doesn't introduce any:

- [ ] Binary files
- [ ] Temporary files, auto-generated files
- [ ] Secret keys
- [ ] Local debugging `print` statements
- [ ] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [ ] tests
