### PR TITLE
Update usage.rst

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -239,6 +239,12 @@ IF / Multichannel CZI
         "title": "input_dir",
         "position": 1
       },
+      "file_name": {
+        "type": "string",
+        "title": "file_name",
+        "position": 2
+      },
+
       "file_share": {
         "type": "string",
         "title": "file_share",


### PR DESCRIPTION

API can now specify single file inputs to CZI pipelines. 
Note, the file name (optional) specified should be in the share/dir_name provided.