### PR TITLE
Fix and keep api reponse log in the slurmlog dir

### DIFF
--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -628,7 +628,7 @@ async def notify_api_completion(flow: Flow, flow_run: FlowRun, state: State) -> 
         async with session.post(
             callback_url, headers=headers, json={"status": status}
         ) as response:
-            hooks_log = open(f"slurm-log/{flowrun_id}-notify-api-completion.txt", "w")
+            hooks_log = open(f"/data/home/svc_hpchedwig_dev/slurm-log/{flowrun_id}/notify-api-completion.txt", "w")
             hooks_log.write(
                 f"Trying to notify: {x_no_api=}, {token=}, {callback_url=}\n"
             )


### PR DESCRIPTION
Error: [ref](https://prefect2.hedwig-workflow-api.niaiddev.net/runs/flow-run/ee885056-3e50-4a77-8e6b-8143f5f5dd4f?tab=Logs)
```
An error was encountered while running hook 'notify_api_completion'
Traceback (most recent call last):
  File "/data/home/svc_hpchedwig_dev/image_portal_workflows/.venv/lib/python3.13/site-packages/prefect/flow_engine.py", line 1137, in call_hooks
    await result
  File "/data/home/svc_hpchedwig_dev/image_portal_workflows/em_workflows/utils/utils.py", line 631, in notify_api_completion
    hooks_log = open(f"slurm-log/{flowrun_id}-notify-api-completion.txt", "w")
FileNotFoundError: [Errno 2] No such file or directory: 'slurm-log/ee885056-3e50-4a77-8e6b-8143f5f5dd4f-notify-api-completion.txt'
```
