### PR TITLE
Use input filepath for bioformats2raw operation

### DIFF
--- a/em_workflows/czi/flow.py
+++ b/em_workflows/czi/flow.py
@@ -171,7 +171,7 @@ def generate_zarr(file_path: FilePath):
     """
     Uses bioformats2raw command to convert czi file to OME-NGFF zarr file
     """
-    input_czi = f"{file_path.proj_dir}/{file_path.base}.czi"
+    input_czi = file_path.fp_in.as_posix()
     ng.bioformats_gen_zarr(
         file_path=file_path,
         input_fname=input_czi,


### PR DESCRIPTION
Enables SVS file to be process by the CZI pipeline by using the input file name instead of the input base with a czi extension.
