### PR TITLE
Support multi-extension single files

### DIFF
--- a/em_workflows/utils/utils.py
+++ b/em_workflows/utils/utils.py
@@ -495,9 +495,8 @@ def list_files(
     _files = list()
     if single_file:
         log(f"Looking for single file: {single_file} in {input_dir}")
-        fp = Path(f"{input_dir}/{single_file}")
-        ext = fp.suffix.strip(".")
-        if ext in exts:
+        fp = input_dir / single_file
+        if any([single_file.endswith(f".{e}") for e in exts]):
             if not fp.exists():
                 raise RuntimeError(
                     f"Expected file: {single_file}, not found in input_dir"


### PR DESCRIPTION
Specifically support ome.tff file suffix.

Addresses (eg: #1)

Depends on (eg: #1)

### Changes

* List of changes
* Breaking changes
* Changes to configurations

### This PR doesn't introduce any:

- [ ] Binary files
- [ ] Temporary files, auto-generated files
- [ ] Secret keys
- [ ] Local debugging `print` statements
- [ ] Unwanted comments (e.g: \# Gets user from environment for code `os.environ['user']` )

### This PR contains valid:

- [ ] tests
